### PR TITLE
Customize Rake tasks

### DIFF
--- a/lib/tasks/testing.rake
+++ b/lib/tasks/testing.rake
@@ -1,0 +1,12 @@
+require 'rubocop/rake_task'
+
+desc 'Run rubocop'
+task :rubocop do
+  RuboCop::RakeTask.new
+end
+
+# reassign unused 'test' task
+task test: [:rubocop, :spec]
+
+# overwrite 'default' task to invoke 'test'
+task(:default).clear.enhance([:test])


### PR DESCRIPTION
Sets up both `rake` and `rake test` to run Rubocop and Rspec for the project.