### PR TITLE
Deprecate jQuery from the project

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,10 +17,12 @@ gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
-# Use jquery as the JavaScript library
-gem 'jquery-rails'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
+
+# Use jquery as the JavaScript library
+# NOTE: Please think twice before enabling jQuery!
+# gem 'jquery-rails'
 
 gem 'haml-rails'
 gem 'webpack-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,10 +115,6 @@ GEM
     jbuilder (2.6.1)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
-    jquery-rails (4.2.1)
-      rails-dom-testing (>= 1, < 3)
-      railties (>= 4.2.0)
-      thor (>= 0.14, < 2.0)
     json (2.0.2)
     jwt (1.5.6)
     listen (3.0.8)
@@ -283,7 +279,6 @@ DEPENDENCIES
   foreman
   haml-rails
   jbuilder (~> 2.5)
-  jquery-rails
   kinetic!
   listen (~> 3.0.5)
   puma (~> 3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,8 +10,10 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery
-//= require jquery_ujs
+/// NOTE: Please think twice before enabling jQuery!
+/// require jquery
+/// require jquery_ujs
+//
 //= require_tree .
 
 console.log("Hello world from sprockets");


### PR DESCRIPTION
After [this discussion](https://github.com/artsy/rosalind/pull/9#discussion_r94457573) about removing jQuery altogether, this PR…  

- disables the jQuery gem and helpers, since our goal is to avoid using them
- adds some noodges in the comments to discourage re-enabling them

This does not preclude continuing to use Sprockets for JS sprinkles in non-React pages.

If jQuery-like functionality is needed for such pages, always good to remember:

- http://youmightnotneedjquery.com
- https://github.com/oneuijs/You-Dont-Need-jQuery

