### PR TITLE
Add a git pre-push hook to force linting before CI

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -3,7 +3,7 @@
 # Exit if any subcommand fails
 set -e
 
-STEPS=6
+STEPS=7
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -56,6 +56,11 @@ git fetch --all --quiet > /dev/null
 # STEP 6
 printf "${CLEAR_LINE}[6/${STEPS}]  setting up dotenv"
 copy_env
+
+# STEP 7
+printf "${CLEAR_LINE}[7/${STEPS}]  adding pre-push git hook"
+cp scripts/git.pre-push.sample .git/hooks/pre-push
+chmod +x .git/hooks/pre-push
 
 # FINISH
 printf "${CLEAR_LINE}[6/${STEPS}]${GREEN}  finished!${NO_COLOR}\n"

--- a/scripts/git.pre-push.sample
+++ b/scripts/git.pre-push.sample
@@ -1,0 +1,11 @@
+#! /usr/bin/env ruby
+
+rb_changed = `git diff-index HEAD --name-only --diff-filter=AM | grep '\.rb$'`.split(/\n/)
+js_changed = `git diff-index HEAD --name-only --diff-filter=AM | grep '\.js$'`.split(/\n/)
+
+exit 0 unless rb_changed.any? || js_changed.any?
+
+rubocop_cmd = "bundle exec rubocop --rails #{rb_changed.join ' '}"
+standard_cmd = "yarn standard #{js_changed.join ' '}"
+
+system(rubocop_cmd) && system(standard_cmd)


### PR DESCRIPTION
This will eliminate some pesky CI roundtrips — let's catch linting errors locally before pushing to a PR branch.