### PR TITLE
Force secure http connection in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,7 +35,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
Adds a missing config for production: force the browser to use https connections.

(This should also fix some login issues some users were having due to attempted OAuth redirect to a non-secure url.)