### PR TITLE
Disable parallelized tests, for CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ test:
     - npm run lint
   override:
     - bundle exec rspec
-    - npm run test
+    - npm run test -- --runInBand
   post:
     - bundle exec danger
 deployment:


### PR DESCRIPTION
There are many reports of slow Jest test runs in Travis and CircleCI, usually fixed by supplying the  `--runinband` option to Jest, which runs all tests in the current process, rather than with a pool of worker processes which is the default.