### PR TITLE
Add an admin-protected Sidekiq dashboard at /sidekiq

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,6 @@
+require 'sidekiq/web'
+require 'admin_constraint'
+
 Rails.application.routes.draw do
   root to: 'pages#batch_update'
 
@@ -9,4 +12,6 @@ Rails.application.routes.draw do
   get 'match/tags'
   get 'match/fairs'
   get 'match/partners'
+
+  mount Sidekiq::Web => '/sidekiq', :constraints => AdminConstraint.new
 end

--- a/lib/admin_constraint.rb
+++ b/lib/admin_constraint.rb
@@ -1,0 +1,8 @@
+# https://github.com/mperham/sidekiq/wiki/Monitoring#restful-authentication-or-sorcery
+class AdminConstraint
+  def matches?(request)
+    return false unless request.session[:current_user]
+    user_type = request.session[:current_user]['type']
+    user_type == 'Admin'
+  end
+end


### PR DESCRIPTION
Now that we are queuing up batch updates to be performed asynchronously by Rosalind, let's make it easier to inspect failed jobs, retries, etc.

We use the session cookie set by Kinetic, along with one of Sidekiq's [recommended strategies](https://github.com/mperham/sidekiq/wiki/Monitoring#restful-authentication-or-sorcery), to restrict access to admins only.

![screen shot 2017-05-30 at 11 31 42 am](https://cloud.githubusercontent.com/assets/140521/26591416/94180928-452b-11e7-8acd-6d8a211850e1.png)