### PR TITLE
Ignore deleted artworks by default when searching

### DIFF
--- a/webpack/apps/batch-update/helpers/elasticsearch.js
+++ b/webpack/apps/batch-update/helpers/elasticsearch.js
@@ -25,6 +25,7 @@ export function buildElasticsearchQuery (args) {
     'query': {
       'bool': {
         'must': [
+          { 'match': { 'deleted': false } },
           ...geneMatches,
           ...tagMatches,
           ...filterMatches,

--- a/webpack/apps/batch-update/helpers/elasticsearch.spec.js
+++ b/webpack/apps/batch-update/helpers/elasticsearch.spec.js
@@ -21,12 +21,41 @@ describe('buildElasticsearchQuery', () => {
     genomedFilter = null
   })
 
+  it('queries only for non-deleted works', () => {
+    const expectedQuery = {
+      'query': {
+        'bool': {
+          'must': [
+            {'match': {'deleted': false}}
+          ]
+        }
+      },
+      'from': 0,
+      'size': 100,
+      'sort': [{'published_at': 'desc'}, {'id': 'desc'}]
+    }
+
+    const params = {
+      createdAfterDate,
+      createdBeforeDate,
+      fair,
+      genes,
+      genomedFilter,
+      partner,
+      publishedFilter,
+      tags
+    }
+    const actualQuery = buildElasticsearchQuery(params)
+    expect(actualQuery).toEqual(expectedQuery)
+  })
+
   describe('main search criteria', () => {
     it('builds a query from the supplied genes', () => {
       const expectedQuery = {
         'query': {
           'bool': {
             'must': [
+              {'match': {'deleted': false}},
               {'match': {'genes': 'Gene 1'}},
               {'match': {'genes': 'Gene 2'}}
             ]
@@ -60,6 +89,7 @@ describe('buildElasticsearchQuery', () => {
         'query': {
           'bool': {
             'must': [
+              {'match': {'deleted': false}},
               {'match': {'tags': 'Tag 1'}},
               {'match': {'tags': 'Tag 2'}}
             ]
@@ -93,6 +123,7 @@ describe('buildElasticsearchQuery', () => {
         'query': {
           'bool': {
             'must': [
+              {'match': {'deleted': false}},
               {'match': {'partner_id': 'some-partner'}}
             ]
           }
@@ -121,6 +152,7 @@ describe('buildElasticsearchQuery', () => {
         'query': {
           'bool': {
             'must': [
+              {'match': {'deleted': false}},
               {'match': {'fair_ids': 'some-fair'}}
             ]
           }
@@ -149,6 +181,7 @@ describe('buildElasticsearchQuery', () => {
         'query': {
           'bool': {
             'must': [
+              {'match': {'deleted': false}},
               {'match': {'genes': 'Gene 1'}}
             ]
           }
@@ -168,6 +201,7 @@ describe('buildElasticsearchQuery', () => {
         'query': {
           'bool': {
             'must': [
+              {'match': {'deleted': false}},
               {'match': {'genes': 'Gene 1'}}
             ]
           }
@@ -189,6 +223,7 @@ describe('buildElasticsearchQuery', () => {
         'query': {
           'bool': {
             'must': [
+              {'match': {'deleted': false}},
               {
                 'range': {
                   'created_at': {
@@ -226,6 +261,7 @@ describe('buildElasticsearchQuery', () => {
         'query': {
           'bool': {
             'must': [
+              {'match': {'deleted': false}},
               {
                 'range': {
                   'created_at': {
@@ -264,6 +300,7 @@ describe('buildElasticsearchQuery', () => {
         'query': {
           'bool': {
             'must': [
+              {'match': {'deleted': false}},
               {
                 'range': {
                   'created_at': {
@@ -306,6 +343,7 @@ describe('buildElasticsearchQuery', () => {
         'query': {
           'bool': {
             'must': [
+              {'match': {'deleted': false}},
               {'match': {'genes': 'Gene 1'}},
               {'match': {'published': true}}
             ]
@@ -335,6 +373,7 @@ describe('buildElasticsearchQuery', () => {
         'query': {
           'bool': {
             'must': [
+              {'match': {'deleted': false}},
               {'match': {'genes': 'Gene 1'}},
               {'match': {'genomed': true}}
             ]


### PR DESCRIPTION
After some discussion we decided to remove the **Deleted** filter from the UI in #94, since the inclusion of deleted works in your search results sets you up for failed genome updates.

That was the correct move as far as the UI goes, but since we were now ignoring the `deleted` status, this left with us with both `deleted: true` and `deleted: false` artworks in the search results.

Which means we were still potentially trying to update deleted artworks and therefore queuing up some jobs that could only fail.

So now we want to go one small step further and _only ever_ return artworks with `deleted: false`, to prevent a bunch of spurious failures.