### PR TITLE
Revert the "published" filter

### DIFF
--- a/webpack/apps/batch-update/components/App.js
+++ b/webpack/apps/batch-update/components/App.js
@@ -31,7 +31,7 @@ class App extends React.Component {
       isSpecifyingBatchUpdate: false,
       partner: null,
       previewedArtwork: null,
-      publishedFilter: 'SHOW_PUBLISHED',
+      publishedFilter: 'SHOW_ALL',
       selectedArtworkIds: [],
       size: 100,
       notices: [],

--- a/webpack/apps/batch-update/components/__snapshots__/App.spec.js.snap
+++ b/webpack/apps/batch-update/components/__snapshots__/App.spec.js.snap
@@ -145,13 +145,13 @@ exports[`test renders correctly 1`] = `
             Published?
           </div>
           <a
-            className={null}
+            className="active"
             href="#"
             onClick={[Function]}>
             All
           </a>
           <a
-            className="active"
+            className={null}
             href="#"
             onClick={[Function]}>
             Published


### PR DESCRIPTION
This was a last minute tweak before the public demo, made bc of what
we thought Rosalind's inability to update unpublished works via Gravity.
Turns out we were wrong, and those failures were a red herring. Yay!