### PR TITLE
Fix user_id column type

### DIFF
--- a/db/migrate/20170801204425_change_user_id_to_string_on_batch_updates.rb
+++ b/db/migrate/20170801204425_change_user_id_to_string_on_batch_updates.rb
@@ -1,0 +1,9 @@
+class ChangeUserIdToStringOnBatchUpdates < ActiveRecord::Migration[5.1]
+  def up
+    change_column :batch_updates, :user_id, :string
+  end
+
+  def down
+    change_column :batch_updates, :user_id, :integer
+  end
+end

--- a/spec/requests/batch_updates_spec.rb
+++ b/spec/requests/batch_updates_spec.rb
@@ -5,7 +5,7 @@ describe 'POST /batch_updates' do
     allow_any_instance_of(BatchUpdatesController).to receive(:find_current_user)
     allow_any_instance_of(BatchUpdatesController).to receive(:is_admin?).and_return(true)
     allow_any_instance_of(BatchUpdatesController).to receive(:is_genomer?).and_return(true)
-    current_user = double(:current_user, id: 123)
+    current_user = double(:current_user, id: 'def456')
     allow_any_instance_of(BatchUpdatesController).to receive(:current_user).and_return(current_user)
   end
 
@@ -26,6 +26,7 @@ describe 'POST /batch_updates' do
       post '/batch_updates', params: payload
 
       expect(BatchUpdate.count).to eq 1
+      expect(BatchUpdate.first.user_id).to eq 'def456'
       jobs = ActiveJob::Base.queue_adapter.enqueued_jobs
       expect(jobs.count).to eq 1
     end


### PR DESCRIPTION
I made a mistake and should have used the string type for the Gravity user id. Since it was an integer, what was happening was that Rosalind was ending up with only the first N number characters of the Gravity user id. :\

This migration fixes that mistake, but then leaves us with those partial ids. Once this migration has been run on production, then the next step is to convert the partial ids to the full ones:

```ruby
map = { 'partial' => 'full' }
map.each { |key, value| BatchUpdate.where(user_id: key).update_all(user_id: value) }
```

I worked with @anandaroop and @reganartsy on coming up with the map that will fix this so I'm ready once this lands on production.