### PR TITLE
Rails upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,6 @@ group :test do
   gem 'chromedriver-helper'
   gem 'database_cleaner'
   gem 'fabrication'
-  gem 'selenium-webdriver', '3.4.3'
+  gem 'selenium-webdriver'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,7 +291,7 @@ GEM
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
-    selenium-webdriver (3.4.3)
+    selenium-webdriver (3.4.4)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
     sentry-raven (2.6.3)
@@ -371,7 +371,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   sass-rails
-  selenium-webdriver (= 3.4.3)
+  selenium-webdriver
   sentry-raven
   sidekiq
   spring


### PR DESCRIPTION
Just trying to get in an upgrade before we deploy #126 to production. I was also able to remove the lock on `selenium-webdriver` - I'm not seeing it be flaky anymore.