### PR TITLE
Tweak CircleCI 2.0 config to use `deploy` section

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,10 +32,11 @@ jobs:
 
       - run: bundle exec danger
 
-      - run: bash .circleci/heroku_setup
       - add_ssh_keys:
           fingerprints:
             - "d1:68:35:96:47:c2:de:36:dd:9f:e4:90:84:be:2e:63"
       - deploy:
           name: Deploy
-          command: .circleci/heroku_deploy
+          command: |
+            .circleci/heroku_setup
+            .circleci/heroku_deploy

--- a/.circleci/heroku_deploy
+++ b/.circleci/heroku_deploy
@@ -9,4 +9,3 @@ if git remote | grep heroku > /dev/null; then
 else
   exit 0
 fi
-


### PR DESCRIPTION
Minor tweak of the `heroku_setup` script to be run under the `deploy` section, as in the [documentation](https://circleci.com/docs/2.0/configuration-reference/#deploy) it seems to be a better place:

> In general deploy step behaves just like run with one exception - in a job with parallelism, the deploy step will only be executed by node #0 and only if all nodes succeed. Nodes other than #0 will skip this step.