### PR TITLE
Upgrade postgres on circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - image: circleci/ruby:2.5.0-node-browsers
         environment:
           RAILS_ENV: test
-      - image: circleci/postgres:9.6.2-alpine
+      - image: circleci/postgres:10.1-alpine
     steps:
       - checkout
 


### PR DESCRIPTION
[Upgrading postgres on Bearden](https://github.com/artsy/bearden/pull/338) went great, so I'm doing it here too. This commit merely changes the version on Circle, so should be green. I'll copy/paste in the commands I run to upgrade at Heroku too, for completeness sake.