### PR TITLE
Ensure heroku is installed

### DIFF
--- a/.circleci/heroku_setup
+++ b/.circleci/heroku_setup
@@ -8,6 +8,7 @@ else
   exit 0
 fi
 
+npm install -g heroku-cli
 git remote add heroku https://git.heroku.com/$app_name.git
 wget https://cli-assets.heroku.com/branches/stable/heroku-linux-amd64.tar.gz
 mkdir -p /usr/local/lib /usr/local/bin


### PR DESCRIPTION
This was installed for us when we were using Circle images, but since switching to Artsy ones, we have to install this ourselves. I had done this with artsy/bearden#348, but forgot to update Rosalind.

Going to selfie-merge this one so that I can babysit a deployment and see it work.