### PR TITLE
Fix Heroku build dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "babel-jest": "^22",
     "babel-loader": "6",
     "babel-plugin-module-resolver": "^3",
+    "babel-plugin-styled-components": "^1.3.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.24.1",
     "chrono-node": "^1.3.5",
@@ -16,6 +17,7 @@
     "enzyme": "^3",
     "enzyme-adapter-react-16": "^1",
     "file-loader": "^1",
+    "jest-styled-components": "^4.9.0",
     "jest": "^22",
     "json-loader": "^0.5.7",
     "lodash.defaults": "^4.2.0",
@@ -37,10 +39,6 @@
     "styled-components": "^2.0",
     "webpack-dev-server": "2.11.2",
     "whatwg-fetch": "^2.0.3"
-  },
-  "devDependencies": {
-    "babel-plugin-styled-components": "^1.3.0",
-    "jest-styled-components": "^4.9.0"
   },
   "jest": {
     "moduleNameMapper": {


### PR DESCRIPTION
Once again we are finding that a Heroku app that uses both the Ruby and Node buildpacks is not seeing the advertised behavior around installing/pruning `devDependencies`.

Fixed by moving deps from `devDependencies` into plain ole `dependencies`.

Pretty much the same situation here as in https://github.com/artsy/volt/pull/3000