### PR TITLE
Ensure test database gets migrated during setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -66,7 +66,8 @@ copy_env
 
 # STEP 7
 printf "${CLEAR_LINE}[7/${STEPS}]  database setup"
-bundle exec rake db:create db:migrate > /dev/null
+RAILS_ENV=development bundle exec rake db:create db:migrate > /dev/null
+RAILS_ENV=test bundle exec rake db:create db:migrate > /dev/null
 
 # STEP 8
 printf "${CLEAR_LINE}[8/${STEPS}]  adding pre-push git hook"


### PR DESCRIPTION
Small tweak to the `bin/setup` script...

I noticed on a fresh install of Rosalind that I couldn't run specs right away because the tables I needed in the `rosalind_test` database didn't exist.

Turns out that 
- `db:create` will create `development` and `test` versions of the database in the absence of an explicit RAILS_ENV
- but `db:migrate` will only migrate the `development` database, leaving your `test` database without any schema at all

So I sprinkled some explicit RAILS_ENVs into the setup code, and I think that will do it.