### PR TITLE
Add Helix link for selected works

### DIFF
--- a/app/javascript/components/batch_update/components/App.js
+++ b/app/javascript/components/batch_update/components/App.js
@@ -420,6 +420,7 @@ class App extends React.Component {
             onRemoveTag={this.onRemoveTag}
             partner={partner}
             publishedFilter={publishedFilter}
+            selectedArtworkIds={selectedArtworkIds}
             selectedArtworksCount={selectedArtworkIds.length}
             tags={tags}
             updateState={this.updateStateFor}

--- a/app/javascript/components/batch_update/components/SearchForm.js
+++ b/app/javascript/components/batch_update/components/SearchForm.js
@@ -14,6 +14,7 @@ import {
 import FilterOptions from './FilterOptions'
 import Button from '@artsy/reaction/dist/Components/Buttons/Default'
 import InvertedButton from '@artsy/reaction/dist/Components/Buttons/Inverted'
+import { Link } from './Links'
 
 const fullWidth = `
   margin: 0;
@@ -37,6 +38,7 @@ class SearchForm extends React.Component {
     const {
       artworksCount,
       selectedArtworksCount,
+      selectedArtworkIds,
       onOpenBatchUpdate
     } = this.props
     if (artworksCount === 0) {
@@ -45,9 +47,15 @@ class SearchForm extends React.Component {
       return <FullWidthButton disabled>Edit Artworks</FullWidthButton>
     } else {
       return (
-        <FullWidthInvertedButton onClick={onOpenBatchUpdate}>
-          Edit Artworks
-        </FullWidthInvertedButton>
+        <React.Fragment>
+          <FullWidthInvertedButton onClick={onOpenBatchUpdate}>
+            Edit Artworks
+          </FullWidthInvertedButton>
+          <HelixLink target='_blank' href={selectedArtworkIds.length > 0 ? `https://helix.artsy.net/genome/artworks?artwork_ids=${selectedArtworkIds.join(',')}` : null}>
+            Open selected in Helix
+          </HelixLink>
+        </React.Fragment>
+
       )
     }
   }
@@ -128,6 +136,11 @@ class SearchForm extends React.Component {
     )
   }
 }
+
+const HelixLink = styled(Link)`
+  display: block;
+  margin-top: 1em;
+`
 
 /* default styled component */
 

--- a/app/javascript/components/batch_update/components/SearchForm.spec.js
+++ b/app/javascript/components/batch_update/components/SearchForm.spec.js
@@ -30,6 +30,7 @@ beforeEach(() => {
     onRemoveArtist: jest.fn(),
     partner: null,
     publishedFilter: 'SHOW_ALL',
+    selectedArtworkIds: [],
     selectedArtworksCount: 0,
     tags: [],
     updateStateFor: jest.fn()

--- a/app/javascript/components/batch_update/components/__snapshots__/App.spec.js.snap
+++ b/app/javascript/components/batch_update/components/__snapshots__/App.spec.js.snap
@@ -159,6 +159,10 @@ exports[`renders correctly 1`] = `
   background: #cccccc;
 }
 
+.c13 {
+  color: #666666;
+}
+
 .c6 {
   margin: 0;
   width: 100%;
@@ -232,10 +236,6 @@ exports[`renders correctly 1`] = `
   background: #6E1FFF;
   border-color: #6E1FFF;
   color: #ffffff;
-}
-
-.c13 {
-  color: #666666;
 }
 
 .c9 {

--- a/app/javascript/components/batch_update/components/__snapshots__/SearchForm.spec.js.snap
+++ b/app/javascript/components/batch_update/components/__snapshots__/SearchForm.spec.js.snap
@@ -925,9 +925,18 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
   background: #6e1fff;
 }
 
+.c8 {
+  color: #666666;
+}
+
 .c4 {
   margin: 0;
   width: 100%;
+}
+
+.c7 {
+  display: block;
+  margin-top: 1em;
 }
 
 <div
@@ -1225,6 +1234,13 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
       Edit Artworks
     </span>
   </button>
+  <a
+    className="c7 c8"
+    href={null}
+    target="_blank"
+  >
+    Open selected in Helix
+  </a>
 </div>
 `;
 


### PR DESCRIPTION
Hackathon 2018, part 5…

Add a handy link to Helix for currently selected artworks. This gives genomers the ability to use Rosalind as a kind of search UI for Helix, and then to switch over to Helix to do Helix-y things:

![helix](https://user-images.githubusercontent.com/140521/48634702-2c273a00-e994-11e8-91d3-28434dce2a32.gif)

