### PR TITLE
Add NSO filtering options

### DIFF
--- a/app/javascript/components/batch_update/components/App.js
+++ b/app/javascript/components/batch_update/components/App.js
@@ -31,7 +31,7 @@ class App extends React.Component {
       isSpecifyingBatchUpdate: false,
       keywords: [],
       notices: [],
-      NSOFilter: 'SHOW_ALL',
+      acquireableOrOfferableFilter: 'SHOW_ALL',
       partner: null,
       previewedArtwork: null,
       publishedFilter: 'SHOW_ALL',
@@ -107,7 +107,8 @@ class App extends React.Component {
       this.state.genes !== prevState.genes ||
       this.state.genomedFilter !== prevState.genomedFilter ||
       this.state.keywords !== prevState.keywords ||
-      this.state.NSOFilter !== prevState.NSOFilter ||
+      this.state.acquireableOrOfferableFilter !==
+        prevState.acquireableOrOfferableFilter ||
       this.state.partner !== prevState.partner ||
       this.state.publishedFilter !== prevState.publishedFilter ||
       this.state.tags !== prevState.tags
@@ -136,7 +137,7 @@ class App extends React.Component {
       genes,
       genomedFilter,
       keywords,
-      NSOFilter,
+      acquireableOrOfferableFilter,
       partner,
       publishedFilter,
       size,
@@ -159,7 +160,7 @@ class App extends React.Component {
         genes,
         genomedFilter,
         keywords,
-        NSOFilter,
+        acquireableOrOfferableFilter,
         partner,
         publishedFilter,
         size,
@@ -190,7 +191,7 @@ class App extends React.Component {
       genes,
       genomedFilter,
       keywords,
-      NSOFilter,
+      acquireableOrOfferableFilter,
       partner,
       publishedFilter,
       tags,
@@ -210,7 +211,7 @@ class App extends React.Component {
       genes,
       genomedFilter,
       keywords,
-      NSOFilter,
+      acquireableOrOfferableFilter,
       partner,
       publishedFilter,
       size,
@@ -396,7 +397,7 @@ class App extends React.Component {
       isLoading,
       isSpecifyingBatchUpdate,
       keywords,
-      NSOFilter,
+      acquireableOrOfferableFilter,
       partner,
       previewedArtwork,
       publishedFilter,
@@ -418,7 +419,7 @@ class App extends React.Component {
             genes={genes}
             genomedFilter={genomedFilter}
             keywords={keywords}
-            NSOFilter={NSOFilter}
+            acquireableOrOfferableFilter={acquireableOrOfferableFilter}
             onAddArtist={this.onAddArtist}
             onAddGene={this.onAddGene}
             onAddKeyword={this.onAddKeyword}

--- a/app/javascript/components/batch_update/components/App.js
+++ b/app/javascript/components/batch_update/components/App.js
@@ -31,6 +31,7 @@ class App extends React.Component {
       isSpecifyingBatchUpdate: false,
       keywords: [],
       notices: [],
+      NSOFilter: 'SHOW_ALL',
       partner: null,
       previewedArtwork: null,
       publishedFilter: 'SHOW_ALL',
@@ -106,6 +107,7 @@ class App extends React.Component {
       this.state.genes !== prevState.genes ||
       this.state.genomedFilter !== prevState.genomedFilter ||
       this.state.keywords !== prevState.keywords ||
+      this.state.NSOFilter !== prevState.NSOFilter ||
       this.state.partner !== prevState.partner ||
       this.state.publishedFilter !== prevState.publishedFilter ||
       this.state.tags !== prevState.tags
@@ -134,6 +136,7 @@ class App extends React.Component {
       genes,
       genomedFilter,
       keywords,
+      NSOFilter,
       partner,
       publishedFilter,
       size,
@@ -156,6 +159,7 @@ class App extends React.Component {
         genes,
         genomedFilter,
         keywords,
+        NSOFilter,
         partner,
         publishedFilter,
         size,
@@ -186,6 +190,7 @@ class App extends React.Component {
       genes,
       genomedFilter,
       keywords,
+      NSOFilter,
       partner,
       publishedFilter,
       tags,
@@ -205,6 +210,7 @@ class App extends React.Component {
       genes,
       genomedFilter,
       keywords,
+      NSOFilter,
       partner,
       publishedFilter,
       size,
@@ -390,6 +396,7 @@ class App extends React.Component {
       isLoading,
       isSpecifyingBatchUpdate,
       keywords,
+      NSOFilter,
       partner,
       previewedArtwork,
       publishedFilter,
@@ -411,6 +418,7 @@ class App extends React.Component {
             genes={genes}
             genomedFilter={genomedFilter}
             keywords={keywords}
+            NSOFilter={NSOFilter}
             onAddArtist={this.onAddArtist}
             onAddGene={this.onAddGene}
             onAddKeyword={this.onAddKeyword}

--- a/app/javascript/components/batch_update/components/FilterOption.js
+++ b/app/javascript/components/batch_update/components/FilterOption.js
@@ -2,22 +2,22 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 function FilterOption(props) {
-  const suffix = props.name.toUpperCase()
+  const suffix = toOptionValue(props.name)
 
   return (
     <div className="filter">
-      <div>{`${capitalize(props.name)}?`}</div>
+      <div>{`${toDisplayName(props.name)}?`}</div>
 
       <Option option="SHOW_ALL" {...props}>
         All
       </Option>
 
       <Option option={`SHOW_${suffix}`} {...props}>
-        {capitalize(props.name)}
+        True
       </Option>
 
       <Option option={`SHOW_NOT_${suffix}`} {...props}>
-        {`Not ${props.name}`}
+        False
       </Option>
     </div>
   )
@@ -53,8 +53,22 @@ function Option(props) {
   )
 }
 
-function capitalize(str) {
-  return str.substring(0, 1).toUpperCase() + str.substring(1)
+const toDisplayName = str => {
+  // un-camelize
+  str = str.replace(/([a-z])([A-Z])/g, '$1 $2')
+  // capitalize first letter
+  str = str.charAt(0).toUpperCase() + str.slice(1)
+  return str
+}
+
+const toOptionValue = str => {
+  // un-camelize
+  str = str.replace(/([a-z])([A-Z])/g, '$1 $2')
+  // add underscores
+  str = str.replace(/\s+/g, '_')
+  // capitalize
+  str = str.toUpperCase()
+  return str
 }
 
 export default FilterOption

--- a/app/javascript/components/batch_update/components/FilterOption.spec.js
+++ b/app/javascript/components/batch_update/components/FilterOption.spec.js
@@ -1,0 +1,83 @@
+import React from 'react'
+import 'jest-styled-components'
+import { mount } from 'enzyme'
+import FilterOption from './FilterOption'
+
+describe('FilterOption', () => {
+  let wrapper
+
+  let props = {
+    name: 'edible', // some predicate about artworks
+    current: 'SHOW_ALL',
+    updateState: jest.fn(),
+  }
+
+  beforeEach(() => {
+    wrapper = mount(<FilterOption {...props} />)
+  })
+
+  describe('display name', () => {
+    it('generates a display name from the provided `name` prop', () => {
+      expect(wrapper.text()).toMatch('Edible?')
+    })
+  })
+
+  describe('filter links', () => {
+    it('generates 3 links', () => {
+      expect(wrapper.find('Option').find('a')).toHaveLength(3)
+    })
+
+    it('generates a link to show all works, ignoring the predicate', () => {
+      const option = wrapper.find('Option').at(0)
+      expect(option.text()).toMatch('All')
+      expect(option.prop('option')).toMatch('SHOW_ALL')
+    })
+
+    it('generates a link to show only works where the predicate is true', () => {
+      const option = wrapper.find('Option').at(1)
+      expect(option.text()).toMatch('True')
+      expect(option.prop('option')).toMatch('SHOW_EDIBLE')
+    })
+
+    it('generates a link to show only works where the predicate is false', () => {
+      const option = wrapper.find('Option').at(2)
+      expect(option.text()).toMatch('False')
+      expect(option.prop('option')).toMatch('SHOW_NOT_EDIBLE')
+    })
+
+    it('highlights the filter link with the currently active value', () => {
+      const showAllOption = wrapper.find('[option="SHOW_ALL"]').find('a')
+      expect(showAllOption.hasClass('active')).toBe(true)
+    })
+  })
+
+  describe('state updates', () => {
+    it('calls a state updater fn when a filter link is clicked', () => {
+      wrapper.find('a').forEach(link => link.simulate('click'))
+      expect(props.updateState).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  describe('with multi-word `name` prop', () => {
+    it('generates readable display name and values', () => {
+      props.name = 'acquireableOrOfferable'
+      wrapper = mount(<FilterOption {...props} />)
+
+      expect(wrapper.text()).toMatch(/Acquireable Or Offerable\?/)
+
+      expect(
+        wrapper
+          .find('Option')
+          .at(1)
+          .prop('option')
+      ).toMatch('SHOW_ACQUIREABLE_OR_OFFERABLE')
+
+      expect(
+        wrapper
+          .find('Option')
+          .at(2)
+          .prop('option')
+      ).toMatch('SHOW_NOT_ACQUIREABLE_OR_OFFERABLE')
+    })
+  })
+})

--- a/app/javascript/components/batch_update/components/FilterOptions.js
+++ b/app/javascript/components/batch_update/components/FilterOptions.js
@@ -7,7 +7,7 @@ function FilterOptions(props) {
     className,
     publishedFilter,
     genomedFilter,
-    NSOFilter,
+    acquireableOrOfferableFilter,
     updateState,
   } = props
 
@@ -23,7 +23,11 @@ function FilterOptions(props) {
         name="genomed"
         updateState={updateState}
       />
-      <FilterOption current={NSOFilter} name="NSO" updateState={updateState} />
+      <FilterOption
+        current={acquireableOrOfferableFilter}
+        name="acquireableOrOfferable"
+        updateState={updateState}
+      />
     </div>
   )
 }
@@ -32,22 +36,22 @@ function FilterOptions(props) {
 
 const StyledFilterOptions = styled(FilterOptions)`
   font-size: 80%;
-  color: #999;
+  color: #333;
   line-height: 140%;
   margin: 2em 0;
-  opacity: 0.25;
-  transition: opacity 0.75s;
+  opacity: 0.5;
+  transition: opacity 0.5s;
 
   &:hover {
     opacity: 1;
-    transition: opacity 0.25s;
+    transition: opacity 0.5s;
   }
 
   .filter {
     margin-top: 1em;
 
     a {
-      color: #ccc;
+      color: #999;
       margin-right: 0.5em;
 
       &.active {

--- a/app/javascript/components/batch_update/components/FilterOptions.js
+++ b/app/javascript/components/batch_update/components/FilterOptions.js
@@ -3,7 +3,13 @@ import styled from 'styled-components'
 import FilterOption from './FilterOption'
 
 function FilterOptions(props) {
-  const { className, publishedFilter, genomedFilter, updateState } = props
+  const {
+    className,
+    publishedFilter,
+    genomedFilter,
+    NSOFilter,
+    updateState,
+  } = props
 
   return (
     <div className={className}>
@@ -17,6 +23,7 @@ function FilterOptions(props) {
         name="genomed"
         updateState={updateState}
       />
+      <FilterOption current={NSOFilter} name="NSO" updateState={updateState} />
     </div>
   )
 }

--- a/app/javascript/components/batch_update/components/SearchForm.js
+++ b/app/javascript/components/batch_update/components/SearchForm.js
@@ -75,7 +75,7 @@ class SearchForm extends React.Component {
       updateState,
     } = this.props
 
-    const { genomedFilter, publishedFilter } = this.props
+    const { genomedFilter, NSOFilter, publishedFilter } = this.props
 
     return (
       <div className={this.props.className}>
@@ -124,6 +124,7 @@ class SearchForm extends React.Component {
 
         <FilterOptions
           genomedFilter={genomedFilter}
+          NSOFilter={NSOFilter}
           publishedFilter={publishedFilter}
           updateState={updateState}
         />

--- a/app/javascript/components/batch_update/components/SearchForm.js
+++ b/app/javascript/components/batch_update/components/SearchForm.js
@@ -75,7 +75,11 @@ class SearchForm extends React.Component {
       updateState,
     } = this.props
 
-    const { genomedFilter, NSOFilter, publishedFilter } = this.props
+    const {
+      genomedFilter,
+      acquireableOrOfferableFilter,
+      publishedFilter,
+    } = this.props
 
     return (
       <div className={this.props.className}>
@@ -124,7 +128,7 @@ class SearchForm extends React.Component {
 
         <FilterOptions
           genomedFilter={genomedFilter}
-          NSOFilter={NSOFilter}
+          acquireableOrOfferableFilter={acquireableOrOfferableFilter}
           publishedFilter={publishedFilter}
           updateState={updateState}
         />

--- a/app/javascript/components/batch_update/components/SearchForm.spec.js
+++ b/app/javascript/components/batch_update/components/SearchForm.spec.js
@@ -18,6 +18,7 @@ beforeEach(() => {
     genes: [],
     genomedFilter: 'SHOW_ALL',
     keywords: [],
+    NSOFilter: 'SHOW_ALL',
     onAddKeyword: jest.fn(),
     onAddGene: jest.fn(),
     onAddTag: jest.fn(),

--- a/app/javascript/components/batch_update/components/SearchForm.spec.js
+++ b/app/javascript/components/batch_update/components/SearchForm.spec.js
@@ -18,7 +18,7 @@ beforeEach(() => {
     genes: [],
     genomedFilter: 'SHOW_ALL',
     keywords: [],
-    NSOFilter: 'SHOW_ALL',
+    acquireableOrOfferableFilter: 'SHOW_ALL',
     onAddKeyword: jest.fn(),
     onAddGene: jest.fn(),
     onAddTag: jest.fn(),

--- a/app/javascript/components/batch_update/components/__snapshots__/App.spec.js.snap
+++ b/app/javascript/components/batch_update/components/__snapshots__/App.spec.js.snap
@@ -750,6 +750,34 @@ exports[`renders correctly 1`] = `
             Not genomed
           </a>
         </div>
+        <div
+          className="filter"
+        >
+          <div>
+            NSO?
+          </div>
+          <a
+            className="active"
+            href="#"
+            onClick={[Function]}
+          >
+            All
+          </a>
+          <a
+            className={null}
+            href="#"
+            onClick={[Function]}
+          >
+            NSO
+          </a>
+          <a
+            className={null}
+            href="#"
+            onClick={[Function]}
+          >
+            Not NSO
+          </a>
+        </div>
       </div>
       <button
         className=" disabled c6"

--- a/app/javascript/components/batch_update/components/__snapshots__/App.spec.js.snap
+++ b/app/javascript/components/batch_update/components/__snapshots__/App.spec.js.snap
@@ -79,18 +79,18 @@ exports[`renders correctly 1`] = `
 
 .c5 {
   font-size: 80%;
-  color: #999;
+  color: #333;
   line-height: 140%;
   margin: 2em 0;
-  opacity: 0.25;
-  -webkit-transition: opacity 0.75s;
-  transition: opacity 0.75s;
+  opacity: 0.5;
+  -webkit-transition: opacity 0.5s;
+  transition: opacity 0.5s;
 }
 
 .c5:hover {
   opacity: 1;
-  -webkit-transition: opacity 0.25s;
-  transition: opacity 0.25s;
+  -webkit-transition: opacity 0.5s;
+  transition: opacity 0.5s;
 }
 
 .c5 .filter {
@@ -98,7 +98,7 @@ exports[`renders correctly 1`] = `
 }
 
 .c5 .filter a {
-  color: #ccc;
+  color: #999;
   margin-right: 0.5em;
 }
 
@@ -712,14 +712,14 @@ exports[`renders correctly 1`] = `
             href="#"
             onClick={[Function]}
           >
-            Published
+            True
           </a>
           <a
             className={null}
             href="#"
             onClick={[Function]}
           >
-            Not published
+            False
           </a>
         </div>
         <div
@@ -740,21 +740,21 @@ exports[`renders correctly 1`] = `
             href="#"
             onClick={[Function]}
           >
-            Genomed
+            True
           </a>
           <a
             className={null}
             href="#"
             onClick={[Function]}
           >
-            Not genomed
+            False
           </a>
         </div>
         <div
           className="filter"
         >
           <div>
-            NSO?
+            Acquireable Or Offerable?
           </div>
           <a
             className="active"
@@ -768,14 +768,14 @@ exports[`renders correctly 1`] = `
             href="#"
             onClick={[Function]}
           >
-            NSO
+            True
           </a>
           <a
             className={null}
             href="#"
             onClick={[Function]}
           >
-            Not NSO
+            False
           </a>
         </div>
       </div>

--- a/app/javascript/components/batch_update/components/__snapshots__/SearchForm.spec.js.snap
+++ b/app/javascript/components/batch_update/components/__snapshots__/SearchForm.spec.js.snap
@@ -373,6 +373,34 @@ exports[`"edit artworks" button does not render an edit button if there are no a
         Not genomed
       </a>
     </div>
+    <div
+      className="filter"
+    >
+      <div>
+        NSO?
+      </div>
+      <a
+        className="active"
+        href="#"
+        onClick={[Function]}
+      >
+        All
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        NSO
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        Not NSO
+      </a>
+    </div>
   </div>
 </div>
 `;
@@ -797,6 +825,34 @@ exports[`"edit artworks" button renders a disabled edit button if there are artw
         onClick={[Function]}
       >
         Not genomed
+      </a>
+    </div>
+    <div
+      className="filter"
+    >
+      <div>
+        NSO?
+      </div>
+      <a
+        className="active"
+        href="#"
+        onClick={[Function]}
+      >
+        All
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        NSO
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        Not NSO
       </a>
     </div>
   </div>
@@ -1255,6 +1311,34 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
         Not genomed
       </a>
     </div>
+    <div
+      className="filter"
+    >
+      <div>
+        NSO?
+      </div>
+      <a
+        className="active"
+        href="#"
+        onClick={[Function]}
+      >
+        All
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        NSO
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        Not NSO
+      </a>
+    </div>
   </div>
   <button
     className="  c4"
@@ -1671,6 +1755,34 @@ exports[`does not render attribution class autosuggest if it is already selected
         Not genomed
       </a>
     </div>
+    <div
+      className="filter"
+    >
+      <div>
+        NSO?
+      </div>
+      <a
+        className="active"
+        href="#"
+        onClick={[Function]}
+      >
+        All
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        NSO
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        Not NSO
+      </a>
+    </div>
   </div>
 </div>
 `;
@@ -2057,6 +2169,34 @@ exports[`does not render fair autosuggest if fair is already selected 1`] = `
         onClick={[Function]}
       >
         Not genomed
+      </a>
+    </div>
+    <div
+      className="filter"
+    >
+      <div>
+        NSO?
+      </div>
+      <a
+        className="active"
+        href="#"
+        onClick={[Function]}
+      >
+        All
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        NSO
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        Not NSO
       </a>
     </div>
   </div>
@@ -2447,6 +2587,34 @@ exports[`does not render partner autosuggest if partner is already selected 1`] 
         Not genomed
       </a>
     </div>
+    <div
+      className="filter"
+    >
+      <div>
+        NSO?
+      </div>
+      <a
+        className="active"
+        href="#"
+        onClick={[Function]}
+      >
+        All
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        NSO
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        Not NSO
+      </a>
+    </div>
   </div>
 </div>
 `;
@@ -2822,6 +2990,34 @@ exports[`renders correctly 1`] = `
         onClick={[Function]}
       >
         Not genomed
+      </a>
+    </div>
+    <div
+      className="filter"
+    >
+      <div>
+        NSO?
+      </div>
+      <a
+        className="active"
+        href="#"
+        onClick={[Function]}
+      >
+        All
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        NSO
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        Not NSO
       </a>
     </div>
   </div>

--- a/app/javascript/components/batch_update/components/__snapshots__/SearchForm.spec.js.snap
+++ b/app/javascript/components/batch_update/components/__snapshots__/SearchForm.spec.js.snap
@@ -44,18 +44,18 @@ exports[`"edit artworks" button does not render an edit button if there are no a
 
 .c3 {
   font-size: 80%;
-  color: #999;
+  color: #333;
   line-height: 140%;
   margin: 2em 0;
-  opacity: 0.25;
-  -webkit-transition: opacity 0.75s;
-  transition: opacity 0.75s;
+  opacity: 0.5;
+  -webkit-transition: opacity 0.5s;
+  transition: opacity 0.5s;
 }
 
 .c3:hover {
   opacity: 1;
-  -webkit-transition: opacity 0.25s;
-  transition: opacity 0.25s;
+  -webkit-transition: opacity 0.5s;
+  transition: opacity 0.5s;
 }
 
 .c3 .filter {
@@ -63,7 +63,7 @@ exports[`"edit artworks" button does not render an edit button if there are no a
 }
 
 .c3 .filter a {
-  color: #ccc;
+  color: #999;
   margin-right: 0.5em;
 }
 
@@ -335,14 +335,14 @@ exports[`"edit artworks" button does not render an edit button if there are no a
         href="#"
         onClick={[Function]}
       >
-        Published
+        True
       </a>
       <a
         className={null}
         href="#"
         onClick={[Function]}
       >
-        Not published
+        False
       </a>
     </div>
     <div
@@ -363,21 +363,21 @@ exports[`"edit artworks" button does not render an edit button if there are no a
         href="#"
         onClick={[Function]}
       >
-        Genomed
+        True
       </a>
       <a
         className={null}
         href="#"
         onClick={[Function]}
       >
-        Not genomed
+        False
       </a>
     </div>
     <div
       className="filter"
     >
       <div>
-        NSO?
+        Acquireable Or Offerable?
       </div>
       <a
         className="active"
@@ -391,14 +391,14 @@ exports[`"edit artworks" button does not render an edit button if there are no a
         href="#"
         onClick={[Function]}
       >
-        NSO
+        True
       </a>
       <a
         className={null}
         href="#"
         onClick={[Function]}
       >
-        Not NSO
+        False
       </a>
     </div>
   </div>
@@ -449,18 +449,18 @@ exports[`"edit artworks" button renders a disabled edit button if there are artw
 
 .c3 {
   font-size: 80%;
-  color: #999;
+  color: #333;
   line-height: 140%;
   margin: 2em 0;
-  opacity: 0.25;
-  -webkit-transition: opacity 0.75s;
-  transition: opacity 0.75s;
+  opacity: 0.5;
+  -webkit-transition: opacity 0.5s;
+  transition: opacity 0.5s;
 }
 
 .c3:hover {
   opacity: 1;
-  -webkit-transition: opacity 0.25s;
-  transition: opacity 0.25s;
+  -webkit-transition: opacity 0.5s;
+  transition: opacity 0.5s;
 }
 
 .c3 .filter {
@@ -468,7 +468,7 @@ exports[`"edit artworks" button renders a disabled edit button if there are artw
 }
 
 .c3 .filter a {
-  color: #ccc;
+  color: #999;
   margin-right: 0.5em;
 }
 
@@ -789,14 +789,14 @@ exports[`"edit artworks" button renders a disabled edit button if there are artw
         href="#"
         onClick={[Function]}
       >
-        Published
+        True
       </a>
       <a
         className={null}
         href="#"
         onClick={[Function]}
       >
-        Not published
+        False
       </a>
     </div>
     <div
@@ -817,21 +817,21 @@ exports[`"edit artworks" button renders a disabled edit button if there are artw
         href="#"
         onClick={[Function]}
       >
-        Genomed
+        True
       </a>
       <a
         className={null}
         href="#"
         onClick={[Function]}
       >
-        Not genomed
+        False
       </a>
     </div>
     <div
       className="filter"
     >
       <div>
-        NSO?
+        Acquireable Or Offerable?
       </div>
       <a
         className="active"
@@ -845,14 +845,14 @@ exports[`"edit artworks" button renders a disabled edit button if there are artw
         href="#"
         onClick={[Function]}
       >
-        NSO
+        True
       </a>
       <a
         className={null}
         href="#"
         onClick={[Function]}
       >
-        Not NSO
+        False
       </a>
     </div>
   </div>
@@ -924,18 +924,18 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
 
 .c3 {
   font-size: 80%;
-  color: #999;
+  color: #333;
   line-height: 140%;
   margin: 2em 0;
-  opacity: 0.25;
-  -webkit-transition: opacity 0.75s;
-  transition: opacity 0.75s;
+  opacity: 0.5;
+  -webkit-transition: opacity 0.5s;
+  transition: opacity 0.5s;
 }
 
 .c3:hover {
   opacity: 1;
-  -webkit-transition: opacity 0.25s;
-  transition: opacity 0.25s;
+  -webkit-transition: opacity 0.5s;
+  transition: opacity 0.5s;
 }
 
 .c3 .filter {
@@ -943,7 +943,7 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
 }
 
 .c3 .filter a {
-  color: #ccc;
+  color: #999;
   margin-right: 0.5em;
 }
 
@@ -1273,14 +1273,14 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
         href="#"
         onClick={[Function]}
       >
-        Published
+        True
       </a>
       <a
         className={null}
         href="#"
         onClick={[Function]}
       >
-        Not published
+        False
       </a>
     </div>
     <div
@@ -1301,21 +1301,21 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
         href="#"
         onClick={[Function]}
       >
-        Genomed
+        True
       </a>
       <a
         className={null}
         href="#"
         onClick={[Function]}
       >
-        Not genomed
+        False
       </a>
     </div>
     <div
       className="filter"
     >
       <div>
-        NSO?
+        Acquireable Or Offerable?
       </div>
       <a
         className="active"
@@ -1329,14 +1329,14 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
         href="#"
         onClick={[Function]}
       >
-        NSO
+        True
       </a>
       <a
         className={null}
         href="#"
         onClick={[Function]}
       >
-        Not NSO
+        False
       </a>
     </div>
   </div>
@@ -1439,18 +1439,18 @@ exports[`does not render attribution class autosuggest if it is already selected
 
 .c4 {
   font-size: 80%;
-  color: #999;
+  color: #333;
   line-height: 140%;
   margin: 2em 0;
-  opacity: 0.25;
-  -webkit-transition: opacity 0.75s;
-  transition: opacity 0.75s;
+  opacity: 0.5;
+  -webkit-transition: opacity 0.5s;
+  transition: opacity 0.5s;
 }
 
 .c4:hover {
   opacity: 1;
-  -webkit-transition: opacity 0.25s;
-  transition: opacity 0.25s;
+  -webkit-transition: opacity 0.5s;
+  transition: opacity 0.5s;
 }
 
 .c4 .filter {
@@ -1458,7 +1458,7 @@ exports[`does not render attribution class autosuggest if it is already selected
 }
 
 .c4 .filter a {
-  color: #ccc;
+  color: #999;
   margin-right: 0.5em;
 }
 
@@ -1717,14 +1717,14 @@ exports[`does not render attribution class autosuggest if it is already selected
         href="#"
         onClick={[Function]}
       >
-        Published
+        True
       </a>
       <a
         className={null}
         href="#"
         onClick={[Function]}
       >
-        Not published
+        False
       </a>
     </div>
     <div
@@ -1745,21 +1745,21 @@ exports[`does not render attribution class autosuggest if it is already selected
         href="#"
         onClick={[Function]}
       >
-        Genomed
+        True
       </a>
       <a
         className={null}
         href="#"
         onClick={[Function]}
       >
-        Not genomed
+        False
       </a>
     </div>
     <div
       className="filter"
     >
       <div>
-        NSO?
+        Acquireable Or Offerable?
       </div>
       <a
         className="active"
@@ -1773,14 +1773,14 @@ exports[`does not render attribution class autosuggest if it is already selected
         href="#"
         onClick={[Function]}
       >
-        NSO
+        True
       </a>
       <a
         className={null}
         href="#"
         onClick={[Function]}
       >
-        Not NSO
+        False
       </a>
     </div>
   </div>
@@ -1855,18 +1855,18 @@ exports[`does not render fair autosuggest if fair is already selected 1`] = `
 
 .c4 {
   font-size: 80%;
-  color: #999;
+  color: #333;
   line-height: 140%;
   margin: 2em 0;
-  opacity: 0.25;
-  -webkit-transition: opacity 0.75s;
-  transition: opacity 0.75s;
+  opacity: 0.5;
+  -webkit-transition: opacity 0.5s;
+  transition: opacity 0.5s;
 }
 
 .c4:hover {
   opacity: 1;
-  -webkit-transition: opacity 0.25s;
-  transition: opacity 0.25s;
+  -webkit-transition: opacity 0.5s;
+  transition: opacity 0.5s;
 }
 
 .c4 .filter {
@@ -1874,7 +1874,7 @@ exports[`does not render fair autosuggest if fair is already selected 1`] = `
 }
 
 .c4 .filter a {
-  color: #ccc;
+  color: #999;
   margin-right: 0.5em;
 }
 
@@ -2133,14 +2133,14 @@ exports[`does not render fair autosuggest if fair is already selected 1`] = `
         href="#"
         onClick={[Function]}
       >
-        Published
+        True
       </a>
       <a
         className={null}
         href="#"
         onClick={[Function]}
       >
-        Not published
+        False
       </a>
     </div>
     <div
@@ -2161,21 +2161,21 @@ exports[`does not render fair autosuggest if fair is already selected 1`] = `
         href="#"
         onClick={[Function]}
       >
-        Genomed
+        True
       </a>
       <a
         className={null}
         href="#"
         onClick={[Function]}
       >
-        Not genomed
+        False
       </a>
     </div>
     <div
       className="filter"
     >
       <div>
-        NSO?
+        Acquireable Or Offerable?
       </div>
       <a
         className="active"
@@ -2189,14 +2189,14 @@ exports[`does not render fair autosuggest if fair is already selected 1`] = `
         href="#"
         onClick={[Function]}
       >
-        NSO
+        True
       </a>
       <a
         className={null}
         href="#"
         onClick={[Function]}
       >
-        Not NSO
+        False
       </a>
     </div>
   </div>
@@ -2271,18 +2271,18 @@ exports[`does not render partner autosuggest if partner is already selected 1`] 
 
 .c4 {
   font-size: 80%;
-  color: #999;
+  color: #333;
   line-height: 140%;
   margin: 2em 0;
-  opacity: 0.25;
-  -webkit-transition: opacity 0.75s;
-  transition: opacity 0.75s;
+  opacity: 0.5;
+  -webkit-transition: opacity 0.5s;
+  transition: opacity 0.5s;
 }
 
 .c4:hover {
   opacity: 1;
-  -webkit-transition: opacity 0.25s;
-  transition: opacity 0.25s;
+  -webkit-transition: opacity 0.5s;
+  transition: opacity 0.5s;
 }
 
 .c4 .filter {
@@ -2290,7 +2290,7 @@ exports[`does not render partner autosuggest if partner is already selected 1`] 
 }
 
 .c4 .filter a {
-  color: #ccc;
+  color: #999;
   margin-right: 0.5em;
 }
 
@@ -2549,14 +2549,14 @@ exports[`does not render partner autosuggest if partner is already selected 1`] 
         href="#"
         onClick={[Function]}
       >
-        Published
+        True
       </a>
       <a
         className={null}
         href="#"
         onClick={[Function]}
       >
-        Not published
+        False
       </a>
     </div>
     <div
@@ -2577,21 +2577,21 @@ exports[`does not render partner autosuggest if partner is already selected 1`] 
         href="#"
         onClick={[Function]}
       >
-        Genomed
+        True
       </a>
       <a
         className={null}
         href="#"
         onClick={[Function]}
       >
-        Not genomed
+        False
       </a>
     </div>
     <div
       className="filter"
     >
       <div>
-        NSO?
+        Acquireable Or Offerable?
       </div>
       <a
         className="active"
@@ -2605,14 +2605,14 @@ exports[`does not render partner autosuggest if partner is already selected 1`] 
         href="#"
         onClick={[Function]}
       >
-        NSO
+        True
       </a>
       <a
         className={null}
         href="#"
         onClick={[Function]}
       >
-        Not NSO
+        False
       </a>
     </div>
   </div>
@@ -2663,18 +2663,18 @@ exports[`renders correctly 1`] = `
 
 .c3 {
   font-size: 80%;
-  color: #999;
+  color: #333;
   line-height: 140%;
   margin: 2em 0;
-  opacity: 0.25;
-  -webkit-transition: opacity 0.75s;
-  transition: opacity 0.75s;
+  opacity: 0.5;
+  -webkit-transition: opacity 0.5s;
+  transition: opacity 0.5s;
 }
 
 .c3:hover {
   opacity: 1;
-  -webkit-transition: opacity 0.25s;
-  transition: opacity 0.25s;
+  -webkit-transition: opacity 0.5s;
+  transition: opacity 0.5s;
 }
 
 .c3 .filter {
@@ -2682,7 +2682,7 @@ exports[`renders correctly 1`] = `
 }
 
 .c3 .filter a {
-  color: #ccc;
+  color: #999;
   margin-right: 0.5em;
 }
 
@@ -2954,14 +2954,14 @@ exports[`renders correctly 1`] = `
         href="#"
         onClick={[Function]}
       >
-        Published
+        True
       </a>
       <a
         className={null}
         href="#"
         onClick={[Function]}
       >
-        Not published
+        False
       </a>
     </div>
     <div
@@ -2982,21 +2982,21 @@ exports[`renders correctly 1`] = `
         href="#"
         onClick={[Function]}
       >
-        Genomed
+        True
       </a>
       <a
         className={null}
         href="#"
         onClick={[Function]}
       >
-        Not genomed
+        False
       </a>
     </div>
     <div
       className="filter"
     >
       <div>
-        NSO?
+        Acquireable Or Offerable?
       </div>
       <a
         className="active"
@@ -3010,14 +3010,14 @@ exports[`renders correctly 1`] = `
         href="#"
         onClick={[Function]}
       >
-        NSO
+        True
       </a>
       <a
         className={null}
         href="#"
         onClick={[Function]}
       >
-        Not NSO
+        False
       </a>
     </div>
   </div>

--- a/app/javascript/components/batch_update/helpers/elasticsearch.js
+++ b/app/javascript/components/batch_update/helpers/elasticsearch.js
@@ -1,4 +1,5 @@
 const defaultPageSize = 100
+const DEBUG = false
 
 export function buildElasticsearchQuery(args) {
   const {
@@ -57,7 +58,7 @@ export function buildElasticsearchQuery(args) {
     }
   })
 
-  return {
+  const query = {
     query: {
       bool: {
         must: [
@@ -78,6 +79,11 @@ export function buildElasticsearchQuery(args) {
     from: from || 0,
     size: size || defaultPageSize,
   }
+
+  if (DEBUG) {
+    console.log(JSON.stringify(query, null, 2))
+  }
+  return query
 }
 
 const buildCreatedDateRange = ({ createdAfterDate, createdBeforeDate }) => {

--- a/app/javascript/components/batch_update/helpers/elasticsearch.js
+++ b/app/javascript/components/batch_update/helpers/elasticsearch.js
@@ -149,33 +149,11 @@ const acquireableOrOfferableMatcher = acquireableOrOfferableFilter => {
   switch (acquireableOrOfferableFilter) {
     case 'SHOW_ACQUIREABLE_OR_OFFERABLE':
       return {
-        or: [
-          {
-            term: {
-              offerable: true,
-            },
-          },
-          {
-            term: {
-              acquireable: true,
-            },
-          },
-        ],
+        or: [{ term: { offerable: true } }, { term: { acquireable: true } }],
       }
     case 'SHOW_NOT_ACQUIREABLE_OR_OFFERABLE':
       return {
-        and: [
-          {
-            term: {
-              offerable: false,
-            },
-          },
-          {
-            term: {
-              acquireable: false,
-            },
-          },
-        ],
+        and: [{ term: { offerable: false } }, { term: { acquireable: false } }],
       }
     default:
       return null

--- a/app/javascript/components/batch_update/helpers/elasticsearch.js
+++ b/app/javascript/components/batch_update/helpers/elasticsearch.js
@@ -12,7 +12,7 @@ export function buildElasticsearchQuery(args) {
     genes,
     genomedFilter,
     keywords,
-    NSOFilter,
+    acquireableOrOfferableFilter,
     partner,
     publishedFilter,
     size,
@@ -31,7 +31,7 @@ export function buildElasticsearchQuery(args) {
   const filterMatches = buildFilterMatches({
     publishedFilter,
     genomedFilter,
-    NSOFilter,
+    acquireableOrOfferableFilter,
   })
   const partnerMatch = partner ? { match: { partner_id: partner.id } } : null
   const fairMatch = fair ? { match: { fair_ids: fair.id } } : null
@@ -113,10 +113,14 @@ const buildCreatedDateRange = ({ createdAfterDate, createdBeforeDate }) => {
   return query
 }
 
-const buildFilterMatches = ({ publishedFilter, genomedFilter, NSOFilter }) => [
+const buildFilterMatches = ({
+  publishedFilter,
+  genomedFilter,
+  acquireableOrOfferableFilter,
+}) => [
   publishedMatcher(publishedFilter),
   genomedMatcher(genomedFilter),
-  NSOMatcher(NSOFilter),
+  acquireableOrOfferableMatcher(acquireableOrOfferableFilter),
 ]
 
 const publishedMatcher = publishedFilter => {
@@ -141,9 +145,9 @@ const genomedMatcher = genomedFilter => {
   }
 }
 
-const NSOMatcher = NSOFilter => {
-  switch (NSOFilter) {
-    case 'SHOW_NSO':
+const acquireableOrOfferableMatcher = acquireableOrOfferableFilter => {
+  switch (acquireableOrOfferableFilter) {
+    case 'SHOW_ACQUIREABLE_OR_OFFERABLE':
       return {
         or: [
           {
@@ -158,7 +162,7 @@ const NSOMatcher = NSOFilter => {
           },
         ],
       }
-    case 'SHOW_NOT_NSO':
+    case 'SHOW_NOT_ACQUIREABLE_OR_OFFERABLE':
       return {
         and: [
           {

--- a/app/javascript/components/batch_update/helpers/elasticsearch.spec.js
+++ b/app/javascript/components/batch_update/helpers/elasticsearch.spec.js
@@ -7,7 +7,7 @@ describe('buildElasticsearchQuery', () => {
     tags,
     keywords,
     artists,
-    NSOFilter,
+    acquireableOrOfferableFilter,
     partner,
     fair,
     attributionClass,
@@ -580,7 +580,7 @@ describe('buildElasticsearchQuery', () => {
       expect(actualQuery).toEqual(expectedQuery)
     })
 
-    it('modifies a query with the value of the "NSO" filter', () => {
+    it('modifies a query with the value of the "acquireable or offerable" filter', () => {
       const expectedQuery = {
         query: {
           bool: {
@@ -600,7 +600,7 @@ describe('buildElasticsearchQuery', () => {
         size: 100,
         sort: [{ published_at: 'desc' }, { id: 'desc' }],
       }
-      NSOFilter = 'SHOW_NSO'
+      acquireableOrOfferableFilter = 'SHOW_ACQUIREABLE_OR_OFFERABLE'
       const params = {
         artists,
         attributionClass,
@@ -610,7 +610,7 @@ describe('buildElasticsearchQuery', () => {
         genes,
         genomedFilter,
         keywords,
-        NSOFilter,
+        acquireableOrOfferableFilter,
         partner,
         publishedFilter,
         tags,

--- a/app/javascript/components/batch_update/helpers/elasticsearch.spec.js
+++ b/app/javascript/components/batch_update/helpers/elasticsearch.spec.js
@@ -7,6 +7,7 @@ describe('buildElasticsearchQuery', () => {
     tags,
     keywords,
     artists,
+    NSOFilter,
     partner,
     fair,
     attributionClass,
@@ -571,6 +572,45 @@ describe('buildElasticsearchQuery', () => {
         genes,
         genomedFilter,
         keywords,
+        partner,
+        publishedFilter,
+        tags,
+      }
+      const actualQuery = buildElasticsearchQuery(params)
+      expect(actualQuery).toEqual(expectedQuery)
+    })
+
+    it('modifies a query with the value of the "NSO" filter', () => {
+      const expectedQuery = {
+        query: {
+          bool: {
+            must: [
+              { match: { deleted: false } },
+              { match: { genes: 'Gene 1' } },
+              {
+                or: [
+                  { term: { offerable: true } },
+                  { term: { acquireable: true } },
+                ],
+              },
+            ],
+          },
+        },
+        from: 0,
+        size: 100,
+        sort: [{ published_at: 'desc' }, { id: 'desc' }],
+      }
+      NSOFilter = 'SHOW_NSO'
+      const params = {
+        artists,
+        attributionClass,
+        createdAfterDate,
+        createdBeforeDate,
+        fair,
+        genes,
+        genomedFilter,
+        keywords,
+        NSOFilter,
         partner,
         publishedFilter,
         tags,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GROW-1226

This gives Rosalind the ability to filter artwork results by whether they are included in NSO (aka New Selling Options aka BNMO aka Buy Now/Make Offer 😅 ) or not.

We use the already-indexed fields `acquireable` and `offerable`  as our signal for whether a work is in NSO.

(Note that these fields do not simply map to the `ecommerce` and `offer` flags on Artwork, but rather to a multi-factorial calculation that [takes into account other artwork attributes](https://github.com/artsy/gravity/blob/5eba2cc781b78fc913ed90b45a56b009860d5500/app/models/util/for_sale.rb#L269-L277) — this matches up with the flags that admins are presently using in Looker to try to accomplish this same kind of filtering.)

- By default all matching works will be shown, whether or not they are included in NSO
- You can explicitly filter for those works which are included, which means either `acquireable` or `offerable`
- You can explicitly filter for those works which are _not_ included, which means neither `acquireable` nor `offerable`

Looks something like this:

![aoro](https://user-images.githubusercontent.com/140521/57805945-1371c400-772c-11e9-8f05-6927af3ecf37.gif)

