### PR TITLE
Update batch-tagging interface

### DIFF
--- a/app/javascript/components/batch_update/components/BatchUpdateForm.js
+++ b/app/javascript/components/batch_update/components/BatchUpdateForm.js
@@ -4,14 +4,14 @@ import styled from 'styled-components'
 import zipObject from 'lodash.zipobject'
 import pickBy from 'lodash.pickby'
 import { Link } from './Links'
-import { Button } from '@artsy/palette'
+import { Button, Sans } from '@artsy/palette'
 import { colors } from './Layout'
 import GeneInput from './GeneInput'
 import { GeneAutosuggest, TagAutosuggest } from './Autosuggest'
 import Overlay from './Overlay'
 import ConfirmationModal from './ConfirmationModal'
 import { submitBatchUpdate } from 'lib/rosalind-api'
-import { SelectedTag } from './Selected'
+import TagInput, { PENDING } from './TagInput'
 
 class BatchUpdateForm extends React.Component {
   constructor(props) {
@@ -183,7 +183,7 @@ class BatchUpdateForm extends React.Component {
   }
 
   onCancelAddTag(name) {
-    const tag = name.substr(1)
+    const tag = name
     const { tagsToAdd } = this.state
     this.setState({
       tagsToAdd: tagsToAdd.filter(t => t !== tag),
@@ -191,7 +191,7 @@ class BatchUpdateForm extends React.Component {
   }
 
   onCancelRemoveTag(name) {
-    const tag = name.substr(1)
+    const tag = name
     const { tagsToRemove } = this.state
     this.setState({
       tagsToRemove: tagsToRemove.filter(t => t !== tag),
@@ -227,29 +227,73 @@ class BatchUpdateForm extends React.Component {
     return output
   }
 
+  renderTagInputs = () => {
+    const currentTags = this.getTagState()
+
+    if (currentTags.length === 0) {
+      return (
+        <EmptyMessage>
+          There aren’t any tags that describe all of your selected works
+        </EmptyMessage>
+      )
+    }
+
+    return (
+      <Inputs>
+        {currentTags.map(item => {
+          const { tag, toAdd, toRemove } = item
+          const tagProps = {
+            name: tag,
+            key: tag,
+            pendingAction: null,
+            onClick: () => this.onRemoveExistingTag(tag),
+          }
+
+          if (toAdd) {
+            tagProps.pendingAction = PENDING.ADD
+            tagProps.onClick = () => this.onCancelAddTag(tag)
+          } else if (toRemove) {
+            tagProps.pendingAction = PENDING.REMOVE
+            tagProps.onClick = () => this.onCancelRemoveTag(tag)
+          }
+
+          return <TagInput {...tagProps} />
+        })}
+      </Inputs>
+    )
+  }
+
+  renderGeneInputs = () => {
+    const { geneValues } = this.state
+    const geneNames = Object.keys(geneValues).sort()
+
+    if (geneNames.length === 0) {
+      return (
+        <EmptyMessage>
+          There aren’t any genes that describe all of your selected works
+        </EmptyMessage>
+      )
+    }
+
+    return (
+      <Inputs>
+        {geneNames.map(name => (
+          <GeneInput
+            key={name}
+            name={name}
+            value={geneValues[name]}
+            onChangeValue={this.onChangeGeneValue}
+          />
+        ))}
+      </Inputs>
+    )
+  }
+
   render() {
     const { selectedArtworkIds } = this.props
     const selectedArtworksCount = selectedArtworkIds.length
-    const { geneValues, isConfirming } = this.state
-    const geneNames = Object.keys(geneValues).sort()
-    const tags = this.getTagState().map(item => {
-      const { tag, toAdd, toRemove } = item
-      const tagProps = {
-        name: tag,
-        key: tag,
-        onRemove: this.onRemoveExistingTag,
-      }
+    const { isConfirming } = this.state
 
-      if (toAdd) {
-        tagProps.toAdd = true
-        tagProps.onRemove = this.onCancelAddTag
-      } else if (toRemove) {
-        tagProps.toRemove = true
-        tagProps.onRemove = this.onCancelRemoveTag
-      }
-
-      return <SelectedTag {...tagProps} />
-    })
     return (
       <Wrapper>
         <Controls>
@@ -266,37 +310,24 @@ class BatchUpdateForm extends React.Component {
           </Button>
         </Controls>
 
-        <h3>Edit Genes</h3>
+        <Sans size="8" mt={3} mb={1}>
+          Tags
+        </Sans>
 
-        <Genes>
-          {geneNames.map(name => (
-            <GeneInput
-              key={name}
-              name={name}
-              value={geneValues[name]}
-              onChangeValue={this.onChangeGeneValue}
-            />
-          ))}
-        </Genes>
+        {this.renderTagInputs()}
 
-        {geneNames.length === 0 && (
-          <EmptyGenesMessage>
-            There aren’t any genes that describe all of your selected works
-          </EmptyGenesMessage>
-        )}
+        <TagAutosuggest placeholder="Add a tag" onSelectTag={this.onAddTag} />
+
+        <Sans size="8" mt={4} mb={1}>
+          Genes
+        </Sans>
+
+        {this.renderGeneInputs()}
 
         <GeneAutosuggest
           placeholder="Add a gene"
           onSelectGene={this.onAddGene}
         />
-
-        <Spacer />
-
-        <h3>Edit Tags</h3>
-        <div>{tags}</div>
-
-        <TagAutosuggest placeholder="Add a tag" onSelectTag={this.onAddTag} />
-        <Spacer />
 
         {isConfirming && <Overlay />}
         <ConfirmationModal
@@ -339,18 +370,18 @@ const Controls = styled.div`
 `
 Controls.displayName = 'Controls'
 
-const Genes = styled.div`
+const Inputs = styled.div`
   display: flex;
   flex-flow: row wrap;
   padding: 30px 0;
 `
-Genes.displayName = 'Genes'
+Inputs.displayName = 'Inputs'
 
-const EmptyGenesMessage = styled.div`
+const EmptyMessage = styled.div`
   align-self: center;
   text-align: center;
 `
-EmptyGenesMessage.displayName = 'EmptyGenesMessage'
+EmptyMessage.displayName = 'EmptyMessage'
 
 const Spacer = styled.div`
   height: 5em;

--- a/app/javascript/components/batch_update/components/BatchUpdateForm.js
+++ b/app/javascript/components/batch_update/components/BatchUpdateForm.js
@@ -338,7 +338,7 @@ class BatchUpdateForm extends React.Component {
           <h1>Are you sure you want to queue these changes?</h1>
           <section>
             <p>
-              You will be changing the genome of {selectedArtworkIds.length}{' '}
+              You will be changing the metadata of {selectedArtworkIds.length}{' '}
               works
             </p>
           </section>
@@ -350,6 +350,7 @@ class BatchUpdateForm extends React.Component {
 
 BatchUpdateForm.propTypes = {
   getCommonGenes: PropTypes.func,
+  getCommonTags: PropTypes.func,
   onAddNotice: PropTypes.func,
   onCancel: PropTypes.func.isRequired,
   selectedArtworkIds: PropTypes.array.isRequired,

--- a/app/javascript/components/batch_update/components/BatchUpdateForm.spec.js
+++ b/app/javascript/components/batch_update/components/BatchUpdateForm.spec.js
@@ -4,8 +4,8 @@ import 'jest-styled-components'
 import { mount } from 'enzyme'
 import BatchUpdateForm from './BatchUpdateForm'
 import GeneInput from './GeneInput'
+import TagInput, { PENDING } from './TagInput'
 import { GeneAutosuggest } from './Autosuggest'
-import { SelectedTag } from './Selected'
 import ConfirmationModal from './ConfirmationModal'
 import * as rosalindApi from 'lib/rosalind-api'
 
@@ -50,7 +50,7 @@ it('renders the common tags for each new artwork selection', () => {
     selectedArtworkIds: ['one', 'two', 'three', 'four'],
   }) // triggers componentWillReceiveProps()
   expect(wrapper.state().existingTags).toEqual(['foo', 'bar'])
-  expect(wrapper.find(SelectedTag).length).toEqual(2)
+  expect(wrapper.find(TagInput).length).toEqual(2)
 })
 
 describe('when the "Cancel" link is clicked', () => {
@@ -105,7 +105,7 @@ it('cancels adding a tag', () => {
   const wrapper = mount(<BatchUpdateForm {...props} />)
   const component = wrapper.instance()
   component.onAddTag({ name: 'foobar' })
-  component.onCancelAddTag('+foobar')
+  component.onCancelAddTag('foobar')
   expect(wrapper.state('tagsToAdd')).toEqual([])
 })
 
@@ -120,7 +120,7 @@ it('cancels removing an existing tag', () => {
   const wrapper = mount(<BatchUpdateForm {...props} />)
   const component = wrapper.instance()
   component.onRemoveExistingTag('foo')
-  component.onCancelRemoveTag('-foo')
+  component.onCancelRemoveTag('foo')
   expect(wrapper.state('tagsToRemove')).toEqual([])
 })
 
@@ -230,27 +230,19 @@ describe('with pending changes', () => {
     })
 
     it('renders the tag state', () => {
-      expect(wrapper.find(SelectedTag).length).toEqual(3)
+      expect(wrapper.find(TagInput).length).toEqual(3)
 
-      expect(wrapper.text()).toMatch('foo')
-      expect(wrapper.text()).not.toMatch('-foo')
-      expect(wrapper.text()).not.toMatch('+foo')
+      expect(
+        wrapper.find('TagInput[name="foo"]').prop('pendingAction')
+      ).toEqual(null)
 
-      expect(wrapper.text()).toMatch('bar')
-      expect(wrapper.text()).not.toMatch('-bar')
-      expect(wrapper.text()).not.toMatch('+bar')
+      expect(
+        wrapper.find('TagInput[name="bar"]').prop('pendingAction')
+      ).toEqual(null)
 
-      expect(wrapper.text()).toMatch('+bang')
-    })
-
-    it('renders pending tag removals with a prefixed minus sign', () => {
-      component.onRemoveExistingTag('foo')
-      expect(wrapper.text()).toMatch('-foo')
-    })
-
-    it('renders pending tag additions with a prefixed plus sign', () => {
-      component.onAddTag({ name: 'boop' })
-      expect(wrapper.text()).toMatch('+boop')
+      expect(
+        wrapper.find('TagInput[name="bang"]').prop('pendingAction')
+      ).toEqual(PENDING.ADD)
     })
   })
 

--- a/app/javascript/components/batch_update/components/BatchUpdateForm.stories.js
+++ b/app/javascript/components/batch_update/components/BatchUpdateForm.stories.js
@@ -5,21 +5,25 @@ import { storiesOf } from '@storybook/react'
 import BatchUpdateForm from './BatchUpdateForm'
 
 let props = {
-  getCommonGenes: () => {},
+  getCommonGenes: () => [],
+  getCommonTags: () => [],
   onAddNotice: () => {},
   onCancel: () => {},
   selectedArtworkIds: [],
 }
 
 storiesOf('BatchUpdateForm', module)
-  .add('with no common genes', () => {
+  .add('with no common genes or tags', () => {
     return <BatchUpdateForm {...props} />
   })
-  .add('with two common genes', () => {
+  .add('with common genes and tags', () => {
     props = {
       ...props,
       getCommonGenes: () => {
         return ['Spray Paint', 'Kawaii']
+      },
+      getCommonTags: () => {
+        return ['Football', 'Hot Dog']
       },
     }
     return (

--- a/app/javascript/components/batch_update/components/BatchUpdateForm.stories.js
+++ b/app/javascript/components/batch_update/components/BatchUpdateForm.stories.js
@@ -11,6 +11,31 @@ let props = {
   selectedArtworkIds: [],
 }
 
-storiesOf('BatchUpdateForm', module).add('default', () => {
-  return <BatchUpdateForm {...props} />
-})
+storiesOf('BatchUpdateForm', module)
+  .add('with no common genes', () => {
+    return <BatchUpdateForm {...props} />
+  })
+  .add('with two common genes', () => {
+    props = {
+      ...props,
+      getCommonGenes: () => {
+        return ['Spray Paint', 'Kawaii']
+      },
+    }
+    return (
+      <>
+        <div
+          style={{
+            width: '100%',
+            background: 'lightGray',
+            color: 'white',
+            textAlign: 'center',
+            padding: '0.5em',
+          }}
+        >
+          (First, click on <u>Cancel</u> to trigger a state update)
+        </div>
+        <BatchUpdateForm {...props} />
+      </>
+    )
+  })

--- a/app/javascript/components/batch_update/components/GeneInput.stories.js
+++ b/app/javascript/components/batch_update/components/GeneInput.stories.js
@@ -1,0 +1,40 @@
+import React from 'react'
+
+import { storiesOf } from '@storybook/react'
+
+import GeneInput from './GeneInput'
+
+class GeneInputWrapper extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      value: this.props.initialValue,
+    }
+  }
+
+  render() {
+    let props = {
+      name: 'Fungible',
+      value: this.state.value,
+      onChangeValue: ({ name, value }) => {
+        console.log('yeah', name, value)
+        this.setState({ value })
+      },
+    }
+    return <GeneInput {...props} />
+  }
+}
+
+storiesOf('GeneInput', module)
+  .add('with a null value', () => {
+    return <GeneInput name="Fungible" value={null} />
+  })
+  .add('with a non-zero value', () => {
+    return <GeneInput name="Fungible" value={70} />
+  })
+  .add('with a zero value', () => {
+    return <GeneInput name="Fungible" value={0} />
+  })
+  .add('interactive', () => {
+    return <GeneInputWrapper initialValue={42} />
+  })

--- a/app/javascript/components/batch_update/components/Selected/SelectedTag.js
+++ b/app/javascript/components/batch_update/components/Selected/SelectedTag.js
@@ -2,27 +2,7 @@ import React from 'react'
 import SelectedComponent from './SelectedComponent'
 
 const SelectedTag = props => {
-  const toAdd = props.toAdd
-  const toRemove = props.toRemove
-  const styleOverrides = {}
-  let name = props.name
-  if (toAdd) {
-    styleOverrides.color = 'green'
-    name = `+${name}`
-  }
-
-  if (toRemove) {
-    styleOverrides.red = 'red'
-    name = `-${name}`
-  }
-
-  return (
-    <SelectedComponent
-      style={styleOverrides}
-      name={name}
-      onRemove={props.onRemove}
-    />
-  )
+  return <SelectedComponent name={props.name} onRemove={props.onRemove} />
 }
 
 export { SelectedTag }

--- a/app/javascript/components/batch_update/components/TagInput.js
+++ b/app/javascript/components/batch_update/components/TagInput.js
@@ -1,0 +1,56 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { colors } from './Layout'
+
+export const PENDING = {
+  ADD: 'ADD',
+  REMOVE: 'REMOVE',
+}
+
+class TagInput extends React.Component {
+  render() {
+    const { name, pendingAction, onClick } = this.props
+    return (
+      <Capsule pendingAction={pendingAction} onClick={onClick}>
+        {pendingAction === PENDING.REMOVE ? <strike>{name}</strike> : name}
+      </Capsule>
+    )
+  }
+}
+
+TagInput.propTypes = {
+  name: PropTypes.string.isRequired,
+  pendingAction: PropTypes.string,
+  onClick: PropTypes.func,
+}
+
+const Capsule = styled.div`
+  ${props => {
+    if (props.pendingAction === PENDING.REMOVE) {
+      return `
+        border: solid 1px ${colors.red};
+        background: ${colors.redLightest};
+      `
+    } else if (props.pendingAction === PENDING.ADD) {
+      return `
+        border: solid 1px ${colors.purple};
+        background: ${colors.purpleLightest};
+      `
+    } else {
+      return `
+        border: solid 1px ${colors.grayLighter};
+        background: ${colors.grayLightest};
+      `
+    }
+  }}
+  border-radius: 5px;
+  cursor: pointer;
+  display: inline-block;
+  margin-bottom: 20px;
+  margin-right: 20px;
+  padding: 10px;
+  user-select: none;
+`
+
+export default TagInput

--- a/app/javascript/components/batch_update/components/TagInput.spec.js
+++ b/app/javascript/components/batch_update/components/TagInput.spec.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import 'jest-styled-components'
+import { mount } from 'enzyme'
+import TagInput, { PENDING } from './TagInput'
+
+it('renders a to-ignore tag correctly', () => {
+  const rendered = renderer.create(
+    <TagInput name="Hot Dog" pendingAction={null} />
+  )
+  const tree = rendered.toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it('renders a to-remove tag correctly', () => {
+  const rendered = renderer.create(
+    <TagInput name="Hot Dog" pendingAction={PENDING.REMOVE} />
+  )
+  const tree = rendered.toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it('renders a to-add tag correctly', () => {
+  const rendered = renderer.create(
+    <TagInput name="Hot Dog" pendingAction={PENDING.ADD} />
+  )
+  const tree = rendered.toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it('accepts changes to the pending action via click events', () => {
+  const changeHandler = jest.fn()
+  const wrapper = mount(
+    <TagInput name="Hot Dog" pendingAction={null} onClick={changeHandler} />
+  )
+  wrapper.find('div').simulate('click')
+  expect(changeHandler.mock.calls.length).toEqual(1)
+})

--- a/app/javascript/components/batch_update/components/TagInput.stories.js
+++ b/app/javascript/components/batch_update/components/TagInput.stories.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import TagInput, { PENDING } from './TagInput'
+
+class TagInputWrapper extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      pendingAction: null,
+    }
+  }
+
+  render() {
+    // cycle through states
+    const nextState = {
+      null: PENDING.REMOVE,
+      [PENDING.REMOVE]: PENDING.ADD,
+      [PENDING.ADD]: null,
+    }
+
+    let props = {
+      name: 'Fungible',
+      pendingAction: this.state.pendingAction,
+      onClick: () => {
+        this.setState(prevState => ({
+          pendingAction: nextState[prevState.pendingAction],
+        }))
+      },
+    }
+
+    return (
+      <>
+        <TagInput {...props} />
+      </>
+    )
+  }
+}
+
+storiesOf('TagInput', module)
+  .add('to be ignored', () => {
+    return <TagInput name="Fungible" pendingAction={null} />
+  })
+  .add('to be added', () => {
+    return <TagInput name="Fungible" pendingAction={PENDING.ADD} />
+  })
+  .add('to be removed', () => {
+    return <TagInput name="Fungible" pendingAction={PENDING.REMOVE} />
+  })
+  .add('interactive', () => {
+    return <TagInputWrapper />
+  })

--- a/app/javascript/components/batch_update/components/__snapshots__/App.spec.js.snap
+++ b/app/javascript/components/batch_update/components/__snapshots__/App.spec.js.snap
@@ -969,7 +969,7 @@ exports[`renders correctly 1`] = `
         </h1>
         <section>
           <p>
-            You will be changing the genome of 
+            You will be changing the metadata of 
             0
              
             works

--- a/app/javascript/components/batch_update/components/__snapshots__/App.spec.js.snap
+++ b/app/javascript/components/batch_update/components/__snapshots__/App.spec.js.snap
@@ -118,6 +118,22 @@ exports[`renders correctly 1`] = `
   padding-top: 1px;
 }
 
+.c15 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 28px;
+  line-height: 36px;
+  margin-bottom: 4px;
+  margin-top: 16px;
+}
+
+.c17 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 28px;
+  line-height: 36px;
+  margin-bottom: 4px;
+  margin-top: 32px;
+}
+
 .c6 {
   cursor: pointer;
   position: relative;
@@ -348,26 +364,11 @@ exports[`renders correctly 1`] = `
   border-bottom: solid 1px #DBDBDB;
 }
 
-.c15 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: row wrap;
-  -ms-flex-flow: row wrap;
-  flex-flow: row wrap;
-  padding: 30px 0;
-}
-
 .c16 {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
   text-align: center;
-}
-
-.c17 {
-  height: 5em;
 }
 
 .c10 {
@@ -874,12 +875,56 @@ exports[`renders correctly 1`] = `
           </div>
         </button>
       </div>
-      <h3>
-        Edit Genes
-      </h3>
       <div
         className="c15"
-      />
+        fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+        fontSize="28px"
+      >
+        Tags
+      </div>
+      <div
+        className="c16"
+      >
+        There aren’t any tags that describe all of your selected works
+      </div>
+      <div
+        className="GenericAutosuggest"
+      >
+        <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
+          aria-owns="react-autowhatever-tag-autosuggest"
+          className="react-autosuggest__container"
+          role="combobox"
+        >
+          <input
+            aria-activedescendant={null}
+            aria-autocomplete="list"
+            aria-controls="react-autowhatever-tag-autosuggest"
+            autoComplete="off"
+            className="react-autosuggest__input"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            placeholder="Add a tag"
+            type="text"
+            value=""
+          />
+          <div
+            className="react-autosuggest__suggestions-container"
+            id="react-autowhatever-tag-autosuggest"
+            role="listbox"
+          />
+        </div>
+      </div>
+      <div
+        className="c17"
+        fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+        fontSize="28px"
+      >
+        Genes
+      </div>
       <div
         className="c16"
       >
@@ -916,47 +961,6 @@ exports[`renders correctly 1`] = `
           />
         </div>
       </div>
-      <div
-        className="c17"
-      />
-      <h3>
-        Edit Tags
-      </h3>
-      <div />
-      <div
-        className="GenericAutosuggest"
-      >
-        <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
-          aria-owns="react-autowhatever-tag-autosuggest"
-          className="react-autosuggest__container"
-          role="combobox"
-        >
-          <input
-            aria-activedescendant={null}
-            aria-autocomplete="list"
-            aria-controls="react-autowhatever-tag-autosuggest"
-            autoComplete="off"
-            className="react-autosuggest__input"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            placeholder="Add a tag"
-            type="text"
-            value=""
-          />
-          <div
-            className="react-autosuggest__suggestions-container"
-            id="react-autowhatever-tag-autosuggest"
-            role="listbox"
-          />
-        </div>
-      </div>
-      <div
-        className="c17"
-      />
       <div
         className="c18"
       >

--- a/app/javascript/components/batch_update/components/__snapshots__/BatchUpdateForm.spec.js.snap
+++ b/app/javascript/components/batch_update/components/__snapshots__/BatchUpdateForm.spec.js.snap
@@ -340,7 +340,7 @@ exports[`renders correctly 1`] = `
     </h1>
     <section>
       <p>
-        You will be changing the genome of 
+        You will be changing the metadata of 
         3
          
         works

--- a/app/javascript/components/batch_update/components/__snapshots__/BatchUpdateForm.spec.js.snap
+++ b/app/javascript/components/batch_update/components/__snapshots__/BatchUpdateForm.spec.js.snap
@@ -13,6 +13,22 @@ exports[`renders correctly 1`] = `
   padding-top: 1px;
 }
 
+.c5 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 28px;
+  line-height: 36px;
+  margin-bottom: 4px;
+  margin-top: 16px;
+}
+
+.c7 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 28px;
+  line-height: 36px;
+  margin-bottom: 4px;
+  margin-top: 32px;
+}
+
 .c3 {
   cursor: pointer;
   position: relative;
@@ -169,26 +185,11 @@ exports[`renders correctly 1`] = `
   border-bottom: solid 1px #DBDBDB;
 }
 
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: row wrap;
-  -ms-flex-flow: row wrap;
-  flex-flow: row wrap;
-  padding: 30px 0;
-}
-
 .c6 {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
   text-align: center;
-}
-
-.c7 {
-  height: 5em;
 }
 
 @media not all and (pointer:coarse),not all and (-moz-touch-enabled:1) {
@@ -245,12 +246,56 @@ exports[`renders correctly 1`] = `
       </div>
     </button>
   </div>
-  <h3>
-    Edit Genes
-  </h3>
   <div
     className="c5"
-  />
+    fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+    fontSize="28px"
+  >
+    Tags
+  </div>
+  <div
+    className="c6"
+  >
+    There aren’t any tags that describe all of your selected works
+  </div>
+  <div
+    className="GenericAutosuggest"
+  >
+    <div
+      aria-expanded={false}
+      aria-haspopup="listbox"
+      aria-owns="react-autowhatever-tag-autosuggest"
+      className="react-autosuggest__container"
+      role="combobox"
+    >
+      <input
+        aria-activedescendant={null}
+        aria-autocomplete="list"
+        aria-controls="react-autowhatever-tag-autosuggest"
+        autoComplete="off"
+        className="react-autosuggest__input"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        placeholder="Add a tag"
+        type="text"
+        value=""
+      />
+      <div
+        className="react-autosuggest__suggestions-container"
+        id="react-autowhatever-tag-autosuggest"
+        role="listbox"
+      />
+    </div>
+  </div>
+  <div
+    className="c7"
+    fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+    fontSize="28px"
+  >
+    Genes
+  </div>
   <div
     className="c6"
   >
@@ -287,47 +332,6 @@ exports[`renders correctly 1`] = `
       />
     </div>
   </div>
-  <div
-    className="c7"
-  />
-  <h3>
-    Edit Tags
-  </h3>
-  <div />
-  <div
-    className="GenericAutosuggest"
-  >
-    <div
-      aria-expanded={false}
-      aria-haspopup="listbox"
-      aria-owns="react-autowhatever-tag-autosuggest"
-      className="react-autosuggest__container"
-      role="combobox"
-    >
-      <input
-        aria-activedescendant={null}
-        aria-autocomplete="list"
-        aria-controls="react-autowhatever-tag-autosuggest"
-        autoComplete="off"
-        className="react-autosuggest__input"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        placeholder="Add a tag"
-        type="text"
-        value=""
-      />
-      <div
-        className="react-autosuggest__suggestions-container"
-        id="react-autowhatever-tag-autosuggest"
-        role="listbox"
-      />
-    </div>
-  </div>
-  <div
-    className="c7"
-  />
   <div
     className="c8"
   >

--- a/app/javascript/components/batch_update/components/__snapshots__/TagInput.spec.js.snap
+++ b/app/javascript/components/batch_update/components/__snapshots__/TagInput.spec.js.snap
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a to-add tag correctly 1`] = `
+.c0 {
+  border: solid 1px #6E1FFF;
+  background: #F7F3FF;
+  border-radius: 5px;
+  cursor: pointer;
+  display: inline-block;
+  margin-bottom: 20px;
+  margin-right: 20px;
+  padding: 10px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+<div
+  className="c0"
+  onClick={undefined}
+>
+  Hot Dog
+</div>
+`;
+
+exports[`renders a to-ignore tag correctly 1`] = `
+.c0 {
+  border: solid 1px #E5E5E5;
+  background: #F8F8F8;
+  border-radius: 5px;
+  cursor: pointer;
+  display: inline-block;
+  margin-bottom: 20px;
+  margin-right: 20px;
+  padding: 10px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+<div
+  className="c0"
+  onClick={undefined}
+>
+  Hot Dog
+</div>
+`;
+
+exports[`renders a to-remove tag correctly 1`] = `
+.c0 {
+  border: solid 1px #F7625A;
+  background: #FFF8F8;
+  border-radius: 5px;
+  cursor: pointer;
+  display: inline-block;
+  margin-bottom: 20px;
+  margin-right: 20px;
+  padding: 10px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+<div
+  className="c0"
+  onClick={undefined}
+>
+  <strike>
+    Hot Dog
+  </strike>
+</div>
+`;


### PR DESCRIPTION
Updates the UX for batch tagging per conversation with stakeholders:

![tagging](https://user-images.githubusercontent.com/140521/58515124-e1bc1c80-8171-11e9-9eb7-6205ab2ac8ee.gif)

(Some of the colors are a bit too subtle for the gif)

This re-uses all the server-side logic and a good chunk of the client-side logic.

The changes that are introduced here do a few things by request:

- Mimics the order of Helix's UI: first tags, then genes
- Uses the same visual conventions as the batch genoming interface

The rest is paperwork of various kinds: wiring up specs & stories; updating specs & snaps.