### PR TITLE
@anandaroop => [Elasticsearch] Replace deprecated `and/or` style ES queries

### DIFF
--- a/app/javascript/components/batch_update/helpers/elasticsearch.js
+++ b/app/javascript/components/batch_update/helpers/elasticsearch.js
@@ -163,11 +163,21 @@ const acquireableOrOfferableMatcher = acquireableOrOfferableFilter => {
   switch (acquireableOrOfferableFilter) {
     case 'SHOW_ACQUIREABLE_OR_OFFERABLE':
       return {
-        or: [{ term: { offerable: true } }, { term: { acquireable: true } }],
+        bool: {
+          should: [
+            { term: { offerable: true } },
+            { term: { acquireable: true } },
+          ],
+        },
       }
     case 'SHOW_NOT_ACQUIREABLE_OR_OFFERABLE':
       return {
-        and: [{ term: { offerable: false } }, { term: { acquireable: false } }],
+        bool: {
+          must: [
+            { term: { offerable: false } },
+            { term: { acquireable: false } },
+          ],
+        },
       }
     default:
       return null

--- a/app/javascript/components/batch_update/helpers/elasticsearch.spec.js
+++ b/app/javascript/components/batch_update/helpers/elasticsearch.spec.js
@@ -722,10 +722,12 @@ describe('buildElasticsearchQuery', () => {
               { match: { deleted: false } },
               { match: { genes: 'Gene 1' } },
               {
-                or: [
-                  { term: { offerable: true } },
-                  { term: { acquireable: true } },
-                ],
+                bool: {
+                  should: [
+                    { term: { offerable: true } },
+                    { term: { acquireable: true } },
+                  ],
+                },
               },
             ],
           },


### PR DESCRIPTION
I believe this is the only place Rosalind directly hits Elasticsearch (it hits Gravity match endpoints, but that's indirectly as it's through Gravity).

One breaking change to the query generated here is that `and` and `or` type queries are no longer supported on v5+ of Elasticsearch, and result in a 4XX syntax error from ES.

This is documented as a [breaking change](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/breaking_50_search_changes.html#_deprecated_queries_removed). Since this should be equivalent anyway in the currently deployed v2 version, this should be good to merge. It's backwards-compatible and works the same in the current version, _and_ will work seamlessly when we [eventually] update the `ELASTICSEARCH_URL...` config vars on Rosalind.