### PR TITLE
Update Elasticsearch queries for ES5 cluster

### DIFF
--- a/app/javascript/components/batch_update/helpers/elasticsearch.js
+++ b/app/javascript/components/batch_update/helpers/elasticsearch.js
@@ -22,10 +22,10 @@ export function buildElasticsearchQuery(args) {
   } = args
 
   const geneMatches = genes.map(g => {
-    return { match: { genes: g.name } }
+    return { match: { 'genes.raw': g.name } }
   })
   const tagMatches = tags.map(t => {
-    return { match: { tags: t.name } }
+    return { match: { 'tags.raw': t.name } }
   })
   const artistMatches = artists.map(a => {
     return { match: { artist_id: a.id } }

--- a/app/javascript/components/batch_update/helpers/elasticsearch.spec.js
+++ b/app/javascript/components/batch_update/helpers/elasticsearch.spec.js
@@ -68,8 +68,8 @@ describe('buildElasticsearchQuery', () => {
           bool: {
             must: [
               { match: { deleted: false } },
-              { match: { genes: 'Gene 1' } },
-              { match: { genes: 'Gene 2' } },
+              { match: { 'genes.raw': 'Gene 1' } },
+              { match: { 'genes.raw': 'Gene 2' } },
             ],
           },
         },
@@ -164,8 +164,8 @@ describe('buildElasticsearchQuery', () => {
           bool: {
             must: [
               { match: { deleted: false } },
-              { match: { tags: 'Tag 1' } },
-              { match: { tags: 'Tag 2' } },
+              { match: { 'tags.raw': 'Tag 1' } },
+              { match: { 'tags.raw': 'Tag 2' } },
             ],
           },
         },
@@ -331,7 +331,7 @@ describe('buildElasticsearchQuery', () => {
           bool: {
             must: [
               { match: { deleted: false } },
-              { match: { genes: 'Gene 1' } },
+              { match: { 'genes.raw': 'Gene 1' } },
             ],
           },
         },
@@ -362,7 +362,7 @@ describe('buildElasticsearchQuery', () => {
           bool: {
             must: [
               { match: { deleted: false } },
-              { match: { genes: 'Gene 1' } },
+              { match: { 'genes.raw': 'Gene 1' } },
             ],
           },
         },
@@ -654,7 +654,7 @@ describe('buildElasticsearchQuery', () => {
           bool: {
             must: [
               { match: { deleted: false } },
-              { match: { genes: 'Gene 1' } },
+              { match: { 'genes.raw': 'Gene 1' } },
               { match: { published: true } },
             ],
           },
@@ -687,7 +687,7 @@ describe('buildElasticsearchQuery', () => {
           bool: {
             must: [
               { match: { deleted: false } },
-              { match: { genes: 'Gene 1' } },
+              { match: { 'genes.raw': 'Gene 1' } },
               { match: { genomed: true } },
             ],
           },
@@ -720,7 +720,7 @@ describe('buildElasticsearchQuery', () => {
           bool: {
             must: [
               { match: { deleted: false } },
-              { match: { genes: 'Gene 1' } },
+              { match: { 'genes.raw': 'Gene 1' } },
               {
                 bool: {
                   should: [


### PR DESCRIPTION
Closes https://artsyproduct.atlassian.net/browse/GROW-1471

Indexing of string fields has changed in more recent versions of Elasticsearch ([background](https://www.elastic.co/blog/strings-are-dead-long-live-strings))

Gravity was [updated accordingly](https://github.com/artsy/gravity/commit/5955a19a6b70f10ed35115bfd233544d122e69e4), and this PR just follows up to make Rosalind compatible with that.

This should be merged & deployed in conjunction with the switch to ES5 in production.