### PR TITLE
Deploy: Update to ES5

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "relay-runtime": "https://github.com/artsy/relay/releases/download/v1.5.0-artsy.3/relay-runtime-1.5.0-artsy.3.tgz"
   },
   "dependencies": {
-    "@artsy/palette": "4.16.1",
+    "@artsy/palette": "4.16.2",
     "@babel/cli": "7.2.0",
     "@babel/core": "7.2.0",
     "@babel/plugin-proposal-class-properties": "7.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@artsy/palette@4.16.1":
-  version "4.16.1"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-4.16.1.tgz#fb257dd118af4916d48ef1e4c8a1285a8bf0a25d"
-  integrity sha512-m/ALEhhAiV+X80YDM12tREtBZiaPzUPHByrLozEJFb8+AquZVSEu73Fn1o8HxNbgTtA+ETWM+GvxOIACa3X+wg==
+"@artsy/palette@4.16.2":
+  version "4.16.2"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-4.16.2.tgz#7fce44661667b2f09956fb6ca4efbccefb9f123e"
+  integrity sha512-2YnFEkJnbH1a6R+yq1ZWpOvRYHnT1u8o1q5juFQCo8g8Q8dXrAp8Jyhspk6+D5qWmuUej7YEszZe/EVlqmiOMA==
   dependencies:
     babel-plugin-styled-components "^1.10.0"
     d3-interpolate "^1.3.2"


### PR DESCRIPTION
Requires a new `ELASTICSEARCH_URL` to be set as well