### PR TITLE
Update README and bin/setup script #hackathon2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,18 @@ $ hokusai dev start
 Rosalind uses Gravity to get detail about some models. See the [gravity
 docs][xapp] for the process.
 
+## Elasticsearch Connection
+
+Rosalind communicates directly with the Elasticsearch cluster to search for
+artworks. Elasticsearch is guarded behind a VPN, so to retrieve artwork search
+results locally, make sure you're connected to VPN associated with the
+environment you're targeting (production or staging).
+
+See documentation available [here][readme-vpn-docs] or [here][infra-vpn-docs]
+
+[readme-vpn-docs]: https://github.com/artsy/potential/blob/master/platform/VPN.md
+[infra-vpn-docs]: https://github.com/artsy/infrastructure#vpn
+
 ## Contributing Pull Requests
 
 Rosalind accepts PRs from branches on the main artsy/rosalind repo. PRs from forks will not be built in the CI environment and cannot be merged directly.

--- a/bin/setup
+++ b/bin/setup
@@ -54,7 +54,6 @@ yarn install > /dev/null
 # STEP 4
 printf "${CLEAR_LINE}[4/${STEPS}]  adding remotes"
 git remote add upstream git@github.com:artsy/rosalind.git
-git remote add staging git@heroku.com:rosalind-staging.git
 
 # STEP 5
 printf "${CLEAR_LINE}[5/${STEPS}]  fetching remotes"
@@ -62,7 +61,7 @@ git fetch --all --quiet > /dev/null
 
 # STEP 6
 printf "${CLEAR_LINE}[6/${STEPS}]  setting up dotenv"
-copy_env
+copy_env hokusai
 
 # STEP 7
 printf "${CLEAR_LINE}[7/${STEPS}]  database setup"

--- a/bin/setup
+++ b/bin/setup
@@ -3,7 +3,7 @@
 # Exit if any subcommand fails
 set -e
 
-STEPS=8
+STEPS=7
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -67,11 +67,6 @@ copy_env hokusai
 printf "${CLEAR_LINE}[7/${STEPS}]  database setup"
 RAILS_ENV=development bundle exec rake db:create db:migrate > /dev/null
 RAILS_ENV=test bundle exec rake db:create db:migrate > /dev/null
-
-# STEP 8
-printf "${CLEAR_LINE}[8/${STEPS}]  adding pre-push git hook"
-cp scripts/git.pre-push.sample .git/hooks/pre-push
-chmod +x .git/hooks/pre-push
 
 # FINISH
 printf "${CLEAR_LINE}[${STEPS}/${STEPS}]${GREEN}  finished!${NO_COLOR}\n"


### PR DESCRIPTION
A couple small adjustments to the bin/setup script after going through the initial setup myself!

- Remove heroku-specific bin/setup instructions
- Remove instruction to add pre-push script
- Add Elasticsearch and VPN documentation to README