### PR TITLE
Remove the genomed filter #hackathon2020

### DIFF
--- a/app/javascript/components/batch_update/components/App.js
+++ b/app/javascript/components/batch_update/components/App.js
@@ -26,7 +26,6 @@ class App extends React.Component {
       createdBeforeDate: null,
       fair: null,
       genes: [],
-      genomedFilter: 'SHOW_ALL',
       isLoading: false,
       isSpecifyingBatchUpdate: false,
       keywords: [],
@@ -107,7 +106,6 @@ class App extends React.Component {
       this.state.createdBeforeDate !== prevState.createdBeforeDate ||
       this.state.fair !== prevState.fair ||
       this.state.genes !== prevState.genes ||
-      this.state.genomedFilter !== prevState.genomedFilter ||
       this.state.keywords !== prevState.keywords ||
       this.state.acquireableOrOfferableFilter !==
         prevState.acquireableOrOfferableFilter ||
@@ -139,7 +137,6 @@ class App extends React.Component {
       createdBeforeDate,
       fair,
       genes,
-      genomedFilter,
       keywords,
       acquireableOrOfferableFilter,
       maxPrice,
@@ -164,7 +161,6 @@ class App extends React.Component {
         createdBeforeDate,
         fair,
         genes,
-        genomedFilter,
         keywords,
         acquireableOrOfferableFilter,
         maxPrice,
@@ -197,7 +193,6 @@ class App extends React.Component {
       createdBeforeDate,
       fair,
       genes,
-      genomedFilter,
       keywords,
       acquireableOrOfferableFilter,
       maxPrice,
@@ -219,7 +214,6 @@ class App extends React.Component {
       fair,
       from,
       genes,
-      genomedFilter,
       keywords,
       acquireableOrOfferableFilter,
       maxPrice,
@@ -415,7 +409,6 @@ class App extends React.Component {
       createdBeforeDate,
       fair,
       genes,
-      genomedFilter,
       isLoading,
       isSpecifyingBatchUpdate,
       keywords,
@@ -441,7 +434,6 @@ class App extends React.Component {
             createdBeforeDate={createdBeforeDate}
             fair={fair}
             genes={genes}
-            genomedFilter={genomedFilter}
             keywords={keywords}
             acquireableOrOfferableFilter={acquireableOrOfferableFilter}
             maxPrice={maxPrice}

--- a/app/javascript/components/batch_update/components/ArtworkPreviewModal.js
+++ b/app/javascript/components/batch_update/components/ArtworkPreviewModal.js
@@ -83,7 +83,6 @@ class ArtworkPreviewModal extends React.Component {
       name,
       image_url: imageUrl,
       published,
-      genomed,
       deleted,
     } = this.props.artwork
     const moreInfo = this.state.fullArtworksById[id]
@@ -102,7 +101,6 @@ class ArtworkPreviewModal extends React.Component {
             <p className="status">
               Deleted: {deleted.toString()} <br />
               Published: {published.toString()} <br />
-              Genomed: {genomed.toString()}
             </p>
             {moreInfo ? (
               <p className="more">

--- a/app/javascript/components/batch_update/components/ArtworkPreviewModal.spec.js
+++ b/app/javascript/components/batch_update/components/ArtworkPreviewModal.spec.js
@@ -15,7 +15,6 @@ beforeEach(() => {
     image_url: 'can.jpg',
     deleted: false,
     published: true,
-    genomed: true,
     category: 'Painting',
     medium: 'oil on canvas',
     dimensions: {

--- a/app/javascript/components/batch_update/components/ArtworkSearchResult.spec.js
+++ b/app/javascript/components/batch_update/components/ArtworkSearchResult.spec.js
@@ -14,7 +14,6 @@ beforeEach(() => {
       image_url: 'can.jpg',
       deleted: false,
       published: true,
-      genomed: true,
     },
     onPreviewArtwork: jest.fn(),
     onToggleArtwork: jest.fn(),

--- a/app/javascript/components/batch_update/components/FilterOptions.js
+++ b/app/javascript/components/batch_update/components/FilterOptions.js
@@ -6,7 +6,6 @@ function FilterOptions(props) {
   const {
     className,
     publishedFilter,
-    genomedFilter,
     acquireableOrOfferableFilter,
     updateState,
   } = props
@@ -16,11 +15,6 @@ function FilterOptions(props) {
       <FilterOption
         current={publishedFilter}
         name="published"
-        updateState={updateState}
-      />
-      <FilterOption
-        current={genomedFilter}
-        name="genomed"
         updateState={updateState}
       />
       <FilterOption

--- a/app/javascript/components/batch_update/components/SearchForm.js
+++ b/app/javascript/components/batch_update/components/SearchForm.js
@@ -80,11 +80,7 @@ class SearchForm extends React.Component {
       updateState,
     } = this.props
 
-    const {
-      genomedFilter,
-      acquireableOrOfferableFilter,
-      publishedFilter,
-    } = this.props
+    const { acquireableOrOfferableFilter, publishedFilter } = this.props
 
     return (
       <div className={this.props.className}>
@@ -138,7 +134,6 @@ class SearchForm extends React.Component {
           updateState={updateState}
         />
         <FilterOptions
-          genomedFilter={genomedFilter}
           acquireableOrOfferableFilter={acquireableOrOfferableFilter}
           publishedFilter={publishedFilter}
           updateState={updateState}

--- a/app/javascript/components/batch_update/components/SearchForm.spec.js
+++ b/app/javascript/components/batch_update/components/SearchForm.spec.js
@@ -16,7 +16,6 @@ beforeEach(() => {
     createdBeforeDate: null,
     fair: null,
     genes: [],
-    genomedFilter: 'SHOW_ALL',
     keywords: [],
     acquireableOrOfferableFilter: 'SHOW_ALL',
     minPrice: null,

--- a/app/javascript/components/batch_update/components/SearchResults.spec.js
+++ b/app/javascript/components/batch_update/components/SearchResults.spec.js
@@ -12,7 +12,6 @@ beforeEach(() => {
     image_url: 'can.jpg',
     deleted: false,
     published: true,
-    genomed: true,
   }
   shark = {
     id: 'shark',
@@ -20,7 +19,6 @@ beforeEach(() => {
     image_url: 'shark.jpg',
     deleted: false,
     published: true,
-    genomed: true,
   }
   artworks = [soup, shark]
   selectedArtworkIds = []

--- a/app/javascript/components/batch_update/components/__snapshots__/App.spec.js.snap
+++ b/app/javascript/components/batch_update/components/__snapshots__/App.spec.js.snap
@@ -747,34 +747,6 @@ exports[`renders correctly 1`] = `
           className="filter"
         >
           <div>
-            Genomed?
-          </div>
-          <a
-            className="active"
-            href="#"
-            onClick={[Function]}
-          >
-            All
-          </a>
-          <a
-            className={null}
-            href="#"
-            onClick={[Function]}
-          >
-            True
-          </a>
-          <a
-            className={null}
-            href="#"
-            onClick={[Function]}
-          >
-            False
-          </a>
-        </div>
-        <div
-          className="filter"
-        >
-          <div>
             Acquireable Or Offerable?
           </div>
           <a

--- a/app/javascript/components/batch_update/components/__snapshots__/ArtworkPreviewModal.spec.js.snap
+++ b/app/javascript/components/batch_update/components/__snapshots__/ArtworkPreviewModal.spec.js.snap
@@ -152,8 +152,6 @@ exports[`renders correctly 1`] = `
         true
          
         <br />
-        Genomed: 
-        true
       </p>
       …
     </div>

--- a/app/javascript/components/batch_update/components/__snapshots__/SearchForm.spec.js.snap
+++ b/app/javascript/components/batch_update/components/__snapshots__/SearchForm.spec.js.snap
@@ -369,34 +369,6 @@ exports[`"edit artworks" button does not render an edit button if there are no a
       className="filter"
     >
       <div>
-        Genomed?
-      </div>
-      <a
-        className="active"
-        href="#"
-        onClick={[Function]}
-      >
-        All
-      </a>
-      <a
-        className={null}
-        href="#"
-        onClick={[Function]}
-      >
-        True
-      </a>
-      <a
-        className={null}
-        href="#"
-        onClick={[Function]}
-      >
-        False
-      </a>
-    </div>
-    <div
-      className="filter"
-    >
-      <div>
         Acquireable Or Offerable?
       </div>
       <a
@@ -816,34 +788,6 @@ exports[`"edit artworks" button renders a disabled edit button if there are artw
     >
       <div>
         Published?
-      </div>
-      <a
-        className="active"
-        href="#"
-        onClick={[Function]}
-      >
-        All
-      </a>
-      <a
-        className={null}
-        href="#"
-        onClick={[Function]}
-      >
-        True
-      </a>
-      <a
-        className={null}
-        href="#"
-        onClick={[Function]}
-      >
-        False
-      </a>
-    </div>
-    <div
-      className="filter"
-    >
-      <div>
-        Genomed?
       </div>
       <a
         className="active"
@@ -1384,34 +1328,6 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
       className="filter"
     >
       <div>
-        Genomed?
-      </div>
-      <a
-        className="active"
-        href="#"
-        onClick={[Function]}
-      >
-        All
-      </a>
-      <a
-        className={null}
-        href="#"
-        onClick={[Function]}
-      >
-        True
-      </a>
-      <a
-        className={null}
-        href="#"
-        onClick={[Function]}
-      >
-        False
-      </a>
-    </div>
-    <div
-      className="filter"
-    >
-      <div>
         Acquireable Or Offerable?
       </div>
       <a
@@ -1865,34 +1781,6 @@ exports[`does not render attribution class autosuggest if it is already selected
       className="filter"
     >
       <div>
-        Genomed?
-      </div>
-      <a
-        className="active"
-        href="#"
-        onClick={[Function]}
-      >
-        All
-      </a>
-      <a
-        className={null}
-        href="#"
-        onClick={[Function]}
-      >
-        True
-      </a>
-      <a
-        className={null}
-        href="#"
-        onClick={[Function]}
-      >
-        False
-      </a>
-    </div>
-    <div
-      className="filter"
-    >
-      <div>
         Acquireable Or Offerable?
       </div>
       <a
@@ -2274,34 +2162,6 @@ exports[`does not render fair autosuggest if fair is already selected 1`] = `
     >
       <div>
         Published?
-      </div>
-      <a
-        className="active"
-        href="#"
-        onClick={[Function]}
-      >
-        All
-      </a>
-      <a
-        className={null}
-        href="#"
-        onClick={[Function]}
-      >
-        True
-      </a>
-      <a
-        className={null}
-        href="#"
-        onClick={[Function]}
-      >
-        False
-      </a>
-    </div>
-    <div
-      className="filter"
-    >
-      <div>
-        Genomed?
       </div>
       <a
         className="active"
@@ -2737,34 +2597,6 @@ exports[`does not render partner autosuggest if partner is already selected 1`] 
       className="filter"
     >
       <div>
-        Genomed?
-      </div>
-      <a
-        className="active"
-        href="#"
-        onClick={[Function]}
-      >
-        All
-      </a>
-      <a
-        className={null}
-        href="#"
-        onClick={[Function]}
-      >
-        True
-      </a>
-      <a
-        className={null}
-        href="#"
-        onClick={[Function]}
-      >
-        False
-      </a>
-    </div>
-    <div
-      className="filter"
-    >
-      <div>
         Acquireable Or Offerable?
       </div>
       <a
@@ -3135,34 +2967,6 @@ exports[`renders correctly 1`] = `
     >
       <div>
         Published?
-      </div>
-      <a
-        className="active"
-        href="#"
-        onClick={[Function]}
-      >
-        All
-      </a>
-      <a
-        className={null}
-        href="#"
-        onClick={[Function]}
-      >
-        True
-      </a>
-      <a
-        className={null}
-        href="#"
-        onClick={[Function]}
-      >
-        False
-      </a>
-    </div>
-    <div
-      className="filter"
-    >
-      <div>
-        Genomed?
       </div>
       <a
         className="active"

--- a/app/javascript/components/batch_update/components/__snapshots__/SearchResults.spec.js.snap
+++ b/app/javascript/components/batch_update/components/__snapshots__/SearchResults.spec.js.snap
@@ -399,8 +399,6 @@ exports[`renders a modal when previewing 1`] = `
           true
            
           <br />
-          Genomed: 
-          true
         </p>
         …
       </div>

--- a/app/javascript/components/batch_update/helpers/elasticsearch.js
+++ b/app/javascript/components/batch_update/helpers/elasticsearch.js
@@ -10,7 +10,6 @@ export function buildElasticsearchQuery(args) {
     fair,
     from,
     genes,
-    genomedFilter,
     keywords,
     acquireableOrOfferableFilter,
     partner,
@@ -32,7 +31,6 @@ export function buildElasticsearchQuery(args) {
   })
   const filterMatches = buildFilterMatches({
     publishedFilter,
-    genomedFilter,
     acquireableOrOfferableFilter,
   })
   const partnerMatch = partner ? { match: { partner_id: partner.id } } : null
@@ -120,11 +118,9 @@ const buildCreatedDateRange = ({ createdAfterDate, createdBeforeDate }) => {
 
 const buildFilterMatches = ({
   publishedFilter,
-  genomedFilter,
   acquireableOrOfferableFilter,
 }) => [
   publishedMatcher(publishedFilter),
-  genomedMatcher(genomedFilter),
   acquireableOrOfferableMatcher(acquireableOrOfferableFilter),
 ]
 
@@ -143,17 +139,6 @@ const publishedMatcher = publishedFilter => {
       return { match: { published: true } }
     case 'SHOW_NOT_PUBLISHED':
       return { match: { published: false } }
-    default:
-      return null
-  }
-}
-
-const genomedMatcher = genomedFilter => {
-  switch (genomedFilter) {
-    case 'SHOW_GENOMED':
-      return { match: { genomed: true } }
-    case 'SHOW_NOT_GENOMED':
-      return { match: { genomed: false } }
     default:
       return null
   }

--- a/app/javascript/components/batch_update/helpers/elasticsearch.spec.js
+++ b/app/javascript/components/batch_update/helpers/elasticsearch.spec.js
@@ -687,39 +687,6 @@ describe('buildElasticsearchQuery', () => {
       expect(actualQuery).toEqual(expectedQuery)
     })
 
-    it('modifies a query with the value of the "genomed" filter', () => {
-      const expectedQuery = {
-        query: {
-          bool: {
-            must: [
-              { match: { deleted: false } },
-              { match: { 'genes.raw': 'Gene 1' } },
-              { match: { genomed: true } },
-            ],
-          },
-        },
-        from: 0,
-        size: 100,
-        sort: [{ published_at: 'desc' }, { id: 'desc' }],
-      }
-      genomedFilter = 'SHOW_GENOMED'
-      const params = {
-        artists,
-        attributionClass,
-        createdAfterDate,
-        createdBeforeDate,
-        fair,
-        genes,
-        genomedFilter,
-        keywords,
-        partner,
-        publishedFilter,
-        tags,
-      }
-      const actualQuery = buildElasticsearchQuery(params)
-      expect(actualQuery).toEqual(expectedQuery)
-    })
-
     it('modifies a query with the value of the "acquireable or offerable" filter', () => {
       const expectedQuery = {
         query: {


### PR DESCRIPTION
Discussion: https://artsy.slack.com/archives/CS2US4PL3/p1578520182010600

This gets rid of the **Genomed?** filter — currently deemed less useful — in order to free up some real estate for new form options.

![after22](https://user-images.githubusercontent.com/140521/72098380-57818c80-32ec-11ea-9da7-02f4cc785389.png)
