### PR TITLE
For sale filter #hackathon2020

### DIFF
--- a/app/javascript/components/batch_update/components/App.js
+++ b/app/javascript/components/batch_update/components/App.js
@@ -33,6 +33,7 @@ class App extends React.Component {
       minPrice: null,
       notices: [],
       acquireableOrOfferableFilter: 'SHOW_ALL',
+      forSaleFilter: 'SHOW_ALL',
       partner: null,
       previewedArtwork: null,
       publishedFilter: 'SHOW_ALL',
@@ -109,6 +110,7 @@ class App extends React.Component {
       this.state.keywords !== prevState.keywords ||
       this.state.acquireableOrOfferableFilter !==
         prevState.acquireableOrOfferableFilter ||
+      this.state.forSaleFilter !== prevState.forSaleFilter ||
       this.state.minPrice !== prevState.minPrice ||
       this.state.maxPrice !== prevState.maxPrice ||
       this.state.partner !== prevState.partner ||
@@ -139,6 +141,7 @@ class App extends React.Component {
       genes,
       keywords,
       acquireableOrOfferableFilter,
+      forSaleFilter,
       maxPrice,
       minPrice,
       partner,
@@ -163,6 +166,7 @@ class App extends React.Component {
         genes,
         keywords,
         acquireableOrOfferableFilter,
+        forSaleFilter,
         maxPrice,
         minPrice,
         partner,
@@ -195,6 +199,7 @@ class App extends React.Component {
       genes,
       keywords,
       acquireableOrOfferableFilter,
+      forSaleFilter,
       maxPrice,
       minPrice,
       partner,
@@ -216,6 +221,7 @@ class App extends React.Component {
       genes,
       keywords,
       acquireableOrOfferableFilter,
+      forSaleFilter,
       maxPrice,
       minPrice,
       partner,
@@ -413,6 +419,7 @@ class App extends React.Component {
       isSpecifyingBatchUpdate,
       keywords,
       acquireableOrOfferableFilter,
+      forSaleFilter,
       partner,
       previewedArtwork,
       publishedFilter,
@@ -436,6 +443,7 @@ class App extends React.Component {
             genes={genes}
             keywords={keywords}
             acquireableOrOfferableFilter={acquireableOrOfferableFilter}
+            forSaleFilter={forSaleFilter}
             maxPrice={maxPrice}
             minPrice={minPrice}
             onAddArtist={this.onAddArtist}

--- a/app/javascript/components/batch_update/components/FilterOptions.js
+++ b/app/javascript/components/batch_update/components/FilterOptions.js
@@ -7,6 +7,7 @@ function FilterOptions(props) {
     className,
     publishedFilter,
     acquireableOrOfferableFilter,
+    forSaleFilter,
     updateState,
   } = props
 
@@ -20,6 +21,11 @@ function FilterOptions(props) {
       <FilterOption
         current={acquireableOrOfferableFilter}
         name="acquireableOrOfferable"
+        updateState={updateState}
+      />
+      <FilterOption
+        current={forSaleFilter}
+        name="forSale"
         updateState={updateState}
       />
     </div>

--- a/app/javascript/components/batch_update/components/SearchForm.js
+++ b/app/javascript/components/batch_update/components/SearchForm.js
@@ -80,7 +80,11 @@ class SearchForm extends React.Component {
       updateState,
     } = this.props
 
-    const { acquireableOrOfferableFilter, publishedFilter } = this.props
+    const {
+      acquireableOrOfferableFilter,
+      publishedFilter,
+      forSaleFilter,
+    } = this.props
 
     return (
       <div className={this.props.className}>
@@ -135,6 +139,7 @@ class SearchForm extends React.Component {
         />
         <FilterOptions
           acquireableOrOfferableFilter={acquireableOrOfferableFilter}
+          forSaleFilter={forSaleFilter}
           publishedFilter={publishedFilter}
           updateState={updateState}
         />

--- a/app/javascript/components/batch_update/components/SearchForm.spec.js
+++ b/app/javascript/components/batch_update/components/SearchForm.spec.js
@@ -15,6 +15,7 @@ beforeEach(() => {
     createdAfterDate: null,
     createdBeforeDate: null,
     fair: null,
+    forSaleFilter: 'SHOW_ALL',
     genes: [],
     keywords: [],
     acquireableOrOfferableFilter: 'SHOW_ALL',

--- a/app/javascript/components/batch_update/components/__snapshots__/App.spec.js.snap
+++ b/app/javascript/components/batch_update/components/__snapshots__/App.spec.js.snap
@@ -771,6 +771,34 @@ exports[`renders correctly 1`] = `
             False
           </a>
         </div>
+        <div
+          className="filter"
+        >
+          <div>
+            For Sale?
+          </div>
+          <a
+            className="active"
+            href="#"
+            onClick={[Function]}
+          >
+            All
+          </a>
+          <a
+            className={null}
+            href="#"
+            onClick={[Function]}
+          >
+            True
+          </a>
+          <a
+            className={null}
+            href="#"
+            onClick={[Function]}
+          >
+            False
+          </a>
+        </div>
       </div>
       <button
         className="c6  disabled"

--- a/app/javascript/components/batch_update/components/__snapshots__/SearchForm.spec.js.snap
+++ b/app/javascript/components/batch_update/components/__snapshots__/SearchForm.spec.js.snap
@@ -393,6 +393,34 @@ exports[`"edit artworks" button does not render an edit button if there are no a
         False
       </a>
     </div>
+    <div
+      className="filter"
+    >
+      <div>
+        For Sale?
+      </div>
+      <a
+        className="active"
+        href="#"
+        onClick={[Function]}
+      >
+        All
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        True
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        False
+      </a>
+    </div>
   </div>
 </div>
 `;
@@ -816,6 +844,34 @@ exports[`"edit artworks" button renders a disabled edit button if there are artw
     >
       <div>
         Acquireable Or Offerable?
+      </div>
+      <a
+        className="active"
+        href="#"
+        onClick={[Function]}
+      >
+        All
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        True
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        False
+      </a>
+    </div>
+    <div
+      className="filter"
+    >
+      <div>
+        For Sale?
       </div>
       <a
         className="active"
@@ -1352,6 +1408,34 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
         False
       </a>
     </div>
+    <div
+      className="filter"
+    >
+      <div>
+        For Sale?
+      </div>
+      <a
+        className="active"
+        href="#"
+        onClick={[Function]}
+      >
+        All
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        True
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        False
+      </a>
+    </div>
   </div>
   <button
     className="c4  "
@@ -1805,6 +1889,34 @@ exports[`does not render attribution class autosuggest if it is already selected
         False
       </a>
     </div>
+    <div
+      className="filter"
+    >
+      <div>
+        For Sale?
+      </div>
+      <a
+        className="active"
+        href="#"
+        onClick={[Function]}
+      >
+        All
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        True
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        False
+      </a>
+    </div>
   </div>
 </div>
 `;
@@ -2190,6 +2302,34 @@ exports[`does not render fair autosuggest if fair is already selected 1`] = `
     >
       <div>
         Acquireable Or Offerable?
+      </div>
+      <a
+        className="active"
+        href="#"
+        onClick={[Function]}
+      >
+        All
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        True
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        False
+      </a>
+    </div>
+    <div
+      className="filter"
+    >
+      <div>
+        For Sale?
       </div>
       <a
         className="active"
@@ -2621,6 +2761,34 @@ exports[`does not render partner autosuggest if partner is already selected 1`] 
         False
       </a>
     </div>
+    <div
+      className="filter"
+    >
+      <div>
+        For Sale?
+      </div>
+      <a
+        className="active"
+        href="#"
+        onClick={[Function]}
+      >
+        All
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        True
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        False
+      </a>
+    </div>
   </div>
 </div>
 `;
@@ -2995,6 +3163,34 @@ exports[`renders correctly 1`] = `
     >
       <div>
         Acquireable Or Offerable?
+      </div>
+      <a
+        className="active"
+        href="#"
+        onClick={[Function]}
+      >
+        All
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        True
+      </a>
+      <a
+        className={null}
+        href="#"
+        onClick={[Function]}
+      >
+        False
+      </a>
+    </div>
+    <div
+      className="filter"
+    >
+      <div>
+        For Sale?
       </div>
       <a
         className="active"

--- a/app/javascript/components/batch_update/helpers/elasticsearch.js
+++ b/app/javascript/components/batch_update/helpers/elasticsearch.js
@@ -3,21 +3,22 @@ const DEBUG = false
 
 export function buildElasticsearchQuery(args) {
   const {
+    acquireableOrOfferableFilter,
     artists,
     attributionClass,
     createdAfterDate,
     createdBeforeDate,
     fair,
+    forSaleFilter,
     from,
     genes,
     keywords,
-    acquireableOrOfferableFilter,
+    maxPrice,
+    minPrice,
     partner,
     publishedFilter,
     size,
     tags,
-    minPrice,
-    maxPrice,
   } = args
 
   const geneMatches = genes.map(g => {
@@ -32,6 +33,7 @@ export function buildElasticsearchQuery(args) {
   const filterMatches = buildFilterMatches({
     publishedFilter,
     acquireableOrOfferableFilter,
+    forSaleFilter,
   })
   const partnerMatch = partner ? { match: { partner_id: partner.id } } : null
   const fairMatch = fair ? { match: { fair_ids: fair.id } } : null
@@ -119,9 +121,11 @@ const buildCreatedDateRange = ({ createdAfterDate, createdBeforeDate }) => {
 const buildFilterMatches = ({
   publishedFilter,
   acquireableOrOfferableFilter,
+  forSaleFilter,
 }) => [
   publishedMatcher(publishedFilter),
   acquireableOrOfferableMatcher(acquireableOrOfferableFilter),
+  forSaleMatcher(forSaleFilter),
 ]
 
 const buildPriceMatch = ({ minPrice, maxPrice }) => ({
@@ -164,6 +168,17 @@ const acquireableOrOfferableMatcher = acquireableOrOfferableFilter => {
           ],
         },
       }
+    default:
+      return null
+  }
+}
+
+const forSaleMatcher = forSaleFilter => {
+  switch (forSaleFilter) {
+    case 'SHOW_FOR_SALE':
+      return { match: { for_sale: true } }
+    case 'SHOW_NOT_FOR_SALE':
+      return { match: { for_sale: false } }
     default:
       return null
   }

--- a/app/javascript/components/batch_update/helpers/elasticsearch.spec.js
+++ b/app/javascript/components/batch_update/helpers/elasticsearch.spec.js
@@ -493,5 +493,26 @@ describe('buildElasticsearchQuery', () => {
       const actualQuery = buildElasticsearchQuery(params)
       expect(actualQuery).toEqual(expectedQuery)
     })
+
+    it('modifies a query with the value of the "for sale" filter', () => {
+      const expectedQuery = {
+        query: {
+          bool: {
+            must: [
+              { match: { deleted: false } },
+              { match: { 'genes.raw': 'Gene 1' } },
+              { match: { for_sale: true } },
+            ],
+          },
+        },
+        from: 0,
+        size: 100,
+        sort: [{ published_at: 'desc' }, { id: 'desc' }],
+      }
+      params.forSaleFilter = 'SHOW_FOR_SALE'
+
+      const actualQuery = buildElasticsearchQuery(params)
+      expect(actualQuery).toEqual(expectedQuery)
+    })
   })
 })

--- a/app/javascript/components/batch_update/helpers/elasticsearch.spec.js
+++ b/app/javascript/components/batch_update/helpers/elasticsearch.spec.js
@@ -1,35 +1,24 @@
 import { buildElasticsearchQuery } from './elasticsearch'
 
 describe('buildElasticsearchQuery', () => {
-  let genes,
-    createdAfterDate,
-    createdBeforeDate,
-    tags,
-    keywords,
-    artists,
-    acquireableOrOfferableFilter,
-    partner,
-    fair,
-    attributionClass,
-    publishedFilter,
-    genomedFilter,
-    minPrice,
-    maxPrice
+  let params
 
   beforeEach(() => {
-    createdAfterDate = null
-    createdBeforeDate = null
-    keywords = []
-    genes = []
-    tags = []
-    artists = []
-    partner = null
-    fair = null
-    attributionClass = null
-    publishedFilter = null
-    genomedFilter = null
-    minPrice = null
-    maxPrice = null
+    params = {
+      artists: [],
+      attributionClass: null,
+      createdAfterDate: null,
+      createdBeforeDate: null,
+      fair: null,
+      forSaleFilter: null,
+      genes: [],
+      keywords: [],
+      maxPrice: null,
+      minPrice: null,
+      partner: null,
+      publishedFilter: null,
+      tags: [],
+    }
   })
 
   it('queries only for non-deleted works', () => {
@@ -44,19 +33,6 @@ describe('buildElasticsearchQuery', () => {
       sort: [{ published_at: 'desc' }, { id: 'desc' }],
     }
 
-    const params = {
-      artists,
-      attributionClass,
-      createdAfterDate,
-      createdBeforeDate,
-      fair,
-      genes,
-      genomedFilter,
-      keywords,
-      partner,
-      publishedFilter,
-      tags,
-    }
     const actualQuery = buildElasticsearchQuery(params)
     expect(actualQuery).toEqual(expectedQuery)
   })
@@ -77,24 +53,12 @@ describe('buildElasticsearchQuery', () => {
         size: 100,
         sort: [{ published_at: 'desc' }, { id: 'desc' }],
       }
-      genes = [
+
+      params.genes = [
         { id: 'gene1', name: 'Gene 1' },
         { id: 'gene2', name: 'Gene 2' },
       ]
 
-      const params = {
-        artists,
-        attributionClass,
-        createdAfterDate,
-        createdBeforeDate,
-        fair,
-        genes,
-        genomedFilter,
-        keywords,
-        partner,
-        publishedFilter,
-        tags,
-      }
       const actualQuery = buildElasticsearchQuery(params)
       expect(actualQuery).toEqual(expectedQuery)
     })
@@ -142,21 +106,9 @@ describe('buildElasticsearchQuery', () => {
         size: 100,
         sort: [{ published_at: 'desc' }, { id: 'desc' }],
       }
-      keywords = ['sherman', 'film still']
 
-      const params = {
-        artists,
-        attributionClass,
-        createdAfterDate,
-        createdBeforeDate,
-        fair,
-        genes,
-        genomedFilter,
-        keywords,
-        partner,
-        publishedFilter,
-        tags,
-      }
+      params.keywords = ['sherman', 'film still']
+
       const actualQuery = buildElasticsearchQuery(params)
       expect(actualQuery).toEqual(expectedQuery)
     })
@@ -176,24 +128,12 @@ describe('buildElasticsearchQuery', () => {
         size: 100,
         sort: [{ published_at: 'desc' }, { id: 'desc' }],
       }
-      tags = [
+
+      params.tags = [
         { id: 'tag1', name: 'Tag 1' },
         { id: 'tag2', name: 'Tag 2' },
       ]
 
-      const params = {
-        artists,
-        attributionClass,
-        createdAfterDate,
-        createdBeforeDate,
-        fair,
-        genes,
-        genomedFilter,
-        keywords,
-        partner,
-        publishedFilter,
-        tags,
-      }
       const actualQuery = buildElasticsearchQuery(params)
       expect(actualQuery).toEqual(expectedQuery)
     })
@@ -213,24 +153,12 @@ describe('buildElasticsearchQuery', () => {
         size: 100,
         sort: [{ published_at: 'desc' }, { id: 'desc' }],
       }
-      artists = [
+
+      params.artists = [
         { id: 'artistId1', name: 'Artist 1' },
         { id: 'artistId2', name: 'Artist 2' },
       ]
 
-      const params = {
-        artists,
-        attributionClass,
-        createdAfterDate,
-        createdBeforeDate,
-        fair,
-        genes,
-        genomedFilter,
-        keywords,
-        partner,
-        publishedFilter,
-        tags,
-      }
       const actualQuery = buildElasticsearchQuery(params)
       expect(actualQuery).toEqual(expectedQuery)
     })
@@ -249,20 +177,9 @@ describe('buildElasticsearchQuery', () => {
         size: 100,
         sort: [{ published_at: 'desc' }, { id: 'desc' }],
       }
-      partner = { id: 'some-partner', name: 'Some Partner' }
-      const params = {
-        artists,
-        attributionClass,
-        createdAfterDate,
-        createdBeforeDate,
-        fair,
-        genes,
-        genomedFilter,
-        keywords,
-        partner,
-        publishedFilter,
-        tags,
-      }
+
+      params.partner = { id: 'some-partner', name: 'Some Partner' }
+
       const actualQuery = buildElasticsearchQuery(params)
       expect(actualQuery).toEqual(expectedQuery)
     })
@@ -281,20 +198,9 @@ describe('buildElasticsearchQuery', () => {
         size: 100,
         sort: [{ published_at: 'desc' }, { id: 'desc' }],
       }
-      fair = { id: 'some-fair', name: 'Some Fair' }
-      const params = {
-        artists,
-        attributionClass,
-        createdAfterDate,
-        createdBeforeDate,
-        fair,
-        genes,
-        genomedFilter,
-        keywords,
-        partner,
-        publishedFilter,
-        tags,
-      }
+
+      params.fair = { id: 'some-fair', name: 'Some Fair' }
+
       const actualQuery = buildElasticsearchQuery(params)
       expect(actualQuery).toEqual(expectedQuery)
     })
@@ -313,20 +219,9 @@ describe('buildElasticsearchQuery', () => {
         size: 100,
         sort: [{ published_at: 'desc' }, { id: 'desc' }],
       }
-      attributionClass = { name: 'Ephemera', value: 'ephemera' }
-      const params = {
-        artists,
-        attributionClass,
-        createdAfterDate,
-        createdBeforeDate,
-        fair,
-        genes,
-        genomedFilter,
-        keywords,
-        partner,
-        publishedFilter,
-        tags,
-      }
+
+      params.attributionClass = { name: 'Ephemera', value: 'ephemera' }
+
       const actualQuery = buildElasticsearchQuery(params)
       expect(actualQuery).toEqual(expectedQuery)
     })
@@ -345,20 +240,10 @@ describe('buildElasticsearchQuery', () => {
         size: 11,
         sort: [{ published_at: 'desc' }, { id: 'desc' }],
       }
-      genes = [{ id: 'gene1', name: 'Gene 1' }]
-      const size = 11
-      const actualQuery = buildElasticsearchQuery({
-        artists,
-        attributionClass,
-        fair,
-        genes,
-        genomedFilter,
-        keywords,
-        partner,
-        publishedFilter,
-        size,
-        tags,
-      })
+
+      params.genes = [{ id: 'gene1', name: 'Gene 1' }]
+      params.size = 11
+      const actualQuery = buildElasticsearchQuery(params)
       expect(actualQuery).toEqual(expectedQuery)
     })
 
@@ -376,26 +261,15 @@ describe('buildElasticsearchQuery', () => {
         size: 100,
         sort: [{ published_at: 'desc' }, { id: 'desc' }],
       }
-      genes = [{ id: 'gene1', name: 'Gene 1' }]
-      const from = 111
-      const actualQuery = buildElasticsearchQuery({
-        artists,
-        attributionClass,
-        fair,
-        from,
-        genes,
-        genomedFilter,
-        keywords,
-        partner,
-        publishedFilter,
-        tags,
-      })
+
+      params.genes = [{ id: 'gene1', name: 'Gene 1' }]
+      params.from = 111
+
+      const actualQuery = buildElasticsearchQuery(params)
       expect(actualQuery).toEqual(expectedQuery)
     })
 
     it('modifies a query with a createdAfterDate', () => {
-      createdAfterDate = 'a-real-date'
-
       const expectedQuery = {
         query: {
           bool: {
@@ -404,7 +278,7 @@ describe('buildElasticsearchQuery', () => {
               {
                 range: {
                   created_at: {
-                    gte: createdAfterDate,
+                    gte: '2013-01-01',
                   },
                 },
               },
@@ -416,27 +290,13 @@ describe('buildElasticsearchQuery', () => {
         sort: [{ published_at: 'desc' }, { id: 'desc' }],
       }
 
-      const params = {
-        artists,
-        attributionClass,
-        createdAfterDate,
-        createdBeforeDate,
-        fair,
-        genes,
-        genomedFilter,
-        keywords,
-        partner,
-        publishedFilter,
-        tags,
-      }
+      params.createdAfterDate = '2013-01-01'
 
       const actualQuery = buildElasticsearchQuery(params)
       expect(actualQuery).toEqual(expectedQuery)
     })
 
     it('modifies a query with a createdBeforeDate', () => {
-      createdBeforeDate = 'a-real-date'
-
       const expectedQuery = {
         query: {
           bool: {
@@ -445,7 +305,7 @@ describe('buildElasticsearchQuery', () => {
               {
                 range: {
                   created_at: {
-                    lte: createdBeforeDate,
+                    lte: '2014-01-01',
                   },
                 },
               },
@@ -457,28 +317,13 @@ describe('buildElasticsearchQuery', () => {
         sort: [{ published_at: 'desc' }, { id: 'desc' }],
       }
 
-      const params = {
-        artists,
-        attributionClass,
-        createdAfterDate,
-        createdBeforeDate,
-        fair,
-        genes,
-        genomedFilter,
-        keywords,
-        partner,
-        publishedFilter,
-        tags,
-      }
+      params.createdBeforeDate = '2014-01-01'
 
       const actualQuery = buildElasticsearchQuery(params)
       expect(actualQuery).toEqual(expectedQuery)
     })
 
     it('modifies a query with a createdAfterDate and a createdBeforeDate', () => {
-      createdAfterDate = 'a-real-date'
-      createdBeforeDate = 'another-real-date'
-
       const expectedQuery = {
         query: {
           bool: {
@@ -487,8 +332,8 @@ describe('buildElasticsearchQuery', () => {
               {
                 range: {
                   created_at: {
-                    gte: createdAfterDate,
-                    lte: createdBeforeDate,
+                    gte: '2013-01-01',
+                    lte: '2014-01-01',
                   },
                 },
               },
@@ -500,26 +345,14 @@ describe('buildElasticsearchQuery', () => {
         sort: [{ published_at: 'desc' }, { id: 'desc' }],
       }
 
-      const params = {
-        artists,
-        attributionClass,
-        createdAfterDate,
-        createdBeforeDate,
-        fair,
-        genes,
-        genomedFilter,
-        keywords,
-        partner,
-        publishedFilter,
-        tags,
-      }
+      params.createdAfterDate = '2013-01-01'
+      params.createdBeforeDate = '2014-01-01'
 
       const actualQuery = buildElasticsearchQuery(params)
       expect(actualQuery).toEqual(expectedQuery)
     })
-    it('modifies a query with a minPrice', () => {
-      minPrice = 1000
 
+    it('modifies a query with a minPrice', () => {
       const expectedQuery = {
         query: {
           bool: {
@@ -528,7 +361,7 @@ describe('buildElasticsearchQuery', () => {
               {
                 range: {
                   prices: {
-                    gte: minPrice,
+                    gte: 1000,
                     lte: null,
                   },
                 },
@@ -541,28 +374,13 @@ describe('buildElasticsearchQuery', () => {
         sort: [{ published_at: 'desc' }, { id: 'desc' }],
       }
 
-      const params = {
-        artists,
-        attributionClass,
-        createdAfterDate,
-        createdBeforeDate,
-        fair,
-        genes,
-        genomedFilter,
-        keywords,
-        partner,
-        publishedFilter,
-        tags,
-        minPrice,
-        maxPrice,
-      }
+      params.minPrice = 1000
 
       const actualQuery = buildElasticsearchQuery(params)
       expect(actualQuery).toEqual(expectedQuery)
     })
-    it('modifies a query with a maxPrice', () => {
-      maxPrice = 1000
 
+    it('modifies a query with a maxPrice', () => {
       const expectedQuery = {
         query: {
           bool: {
@@ -572,7 +390,7 @@ describe('buildElasticsearchQuery', () => {
                 range: {
                   prices: {
                     gte: null,
-                    lte: maxPrice,
+                    lte: 1000,
                   },
                 },
               },
@@ -584,29 +402,13 @@ describe('buildElasticsearchQuery', () => {
         sort: [{ published_at: 'desc' }, { id: 'desc' }],
       }
 
-      const params = {
-        artists,
-        attributionClass,
-        createdAfterDate,
-        createdBeforeDate,
-        fair,
-        genes,
-        genomedFilter,
-        keywords,
-        partner,
-        publishedFilter,
-        tags,
-        minPrice,
-        maxPrice,
-      }
+      params.maxPrice = 1000
 
       const actualQuery = buildElasticsearchQuery(params)
       expect(actualQuery).toEqual(expectedQuery)
     })
-    it('modifies a query with both a minPrice and a maxPrice', () => {
-      minPrice = 1000
-      maxPrice = 2000
 
+    it('modifies a query with both a minPrice and a maxPrice', () => {
       const expectedQuery = {
         query: {
           bool: {
@@ -615,8 +417,8 @@ describe('buildElasticsearchQuery', () => {
               {
                 range: {
                   prices: {
-                    gte: minPrice,
-                    lte: maxPrice,
+                    gte: 1000,
+                    lte: 2000,
                   },
                 },
               },
@@ -628,21 +430,8 @@ describe('buildElasticsearchQuery', () => {
         sort: [{ published_at: 'desc' }, { id: 'desc' }],
       }
 
-      const params = {
-        artists,
-        attributionClass,
-        createdAfterDate,
-        createdBeforeDate,
-        fair,
-        genes,
-        genomedFilter,
-        keywords,
-        partner,
-        publishedFilter,
-        tags,
-        minPrice,
-        maxPrice,
-      }
+      params.minPrice = 1000
+      params.maxPrice = 2000
 
       const actualQuery = buildElasticsearchQuery(params)
       expect(actualQuery).toEqual(expectedQuery)
@@ -651,7 +440,7 @@ describe('buildElasticsearchQuery', () => {
 
   describe('status filters', () => {
     beforeEach(() => {
-      genes = [{ id: 'gene1', name: 'Gene 1' }]
+      params.genes = [{ id: 'gene1', name: 'Gene 1' }]
     })
 
     it('modifies a query with the value of the "published" filter', () => {
@@ -669,20 +458,9 @@ describe('buildElasticsearchQuery', () => {
         size: 100,
         sort: [{ published_at: 'desc' }, { id: 'desc' }],
       }
-      publishedFilter = 'SHOW_PUBLISHED'
-      const params = {
-        artists,
-        attributionClass,
-        createdAfterDate,
-        createdBeforeDate,
-        fair,
-        genes,
-        genomedFilter,
-        keywords,
-        partner,
-        publishedFilter,
-        tags,
-      }
+
+      params.publishedFilter = 'SHOW_PUBLISHED'
+
       const actualQuery = buildElasticsearchQuery(params)
       expect(actualQuery).toEqual(expectedQuery)
     })
@@ -709,21 +487,9 @@ describe('buildElasticsearchQuery', () => {
         size: 100,
         sort: [{ published_at: 'desc' }, { id: 'desc' }],
       }
-      acquireableOrOfferableFilter = 'SHOW_ACQUIREABLE_OR_OFFERABLE'
-      const params = {
-        artists,
-        attributionClass,
-        createdAfterDate,
-        createdBeforeDate,
-        fair,
-        genes,
-        genomedFilter,
-        keywords,
-        acquireableOrOfferableFilter,
-        partner,
-        publishedFilter,
-        tags,
-      }
+
+      params.acquireableOrOfferableFilter = 'SHOW_ACQUIREABLE_OR_OFFERABLE'
+
       const actualQuery = buildElasticsearchQuery(params)
       expect(actualQuery).toEqual(expectedQuery)
     })


### PR DESCRIPTION
Adds a new boolean filter that considers the `for_sale` flag on the artwork index in Elasticsearch

![forsale](https://user-images.githubusercontent.com/140521/72099489-b6480580-32ee-11ea-8675-c6b4073b8974.gif)
