### PR TITLE
Add custom sort capability #hackathon2020

### DIFF
--- a/app/javascript/components/batch_update/components/App.js
+++ b/app/javascript/components/batch_update/components/App.js
@@ -116,6 +116,7 @@ class App extends React.Component {
       this.state.maxPrice !== prevState.maxPrice ||
       this.state.partner !== prevState.partner ||
       this.state.publishedFilter !== prevState.publishedFilter ||
+      this.state.sort !== prevState.sort ||
       this.state.tags !== prevState.tags
     )
   }
@@ -429,6 +430,7 @@ class App extends React.Component {
       previewedArtwork,
       publishedFilter,
       selectedArtworkIds,
+      sort,
       tags,
       totalHits,
       minPrice,
@@ -464,6 +466,7 @@ class App extends React.Component {
             publishedFilter={publishedFilter}
             selectedArtworkIds={selectedArtworkIds}
             selectedArtworksCount={selectedArtworkIds.length}
+            sort={sort}
             tags={tags}
             updateState={this.updateStateFor}
           />

--- a/app/javascript/components/batch_update/components/App.js
+++ b/app/javascript/components/batch_update/components/App.js
@@ -39,6 +39,7 @@ class App extends React.Component {
       publishedFilter: 'SHOW_ALL',
       selectedArtworkIds: [],
       size: 100,
+      sort: 'RECENTLY_PUBLISHED',
       tags: [],
       totalHits: null,
     }
@@ -147,6 +148,7 @@ class App extends React.Component {
       partner,
       publishedFilter,
       size,
+      sort,
       tags,
     } = this.state
 
@@ -172,6 +174,7 @@ class App extends React.Component {
         partner,
         publishedFilter,
         size,
+        sort,
         tags,
       })
 
@@ -192,6 +195,7 @@ class App extends React.Component {
   fetchMoreArtworks() {
     const {
       artists,
+      artworks,
       attributionClass,
       createdAfterDate,
       createdBeforeDate,
@@ -204,10 +208,10 @@ class App extends React.Component {
       minPrice,
       partner,
       publishedFilter,
+      size,
+      sort,
       tags,
     } = this.state
-
-    const { artworks, size } = this.state
 
     const from = artworks.length
 
@@ -227,6 +231,7 @@ class App extends React.Component {
       partner,
       publishedFilter,
       size,
+      sort,
       tags,
     })
 

--- a/app/javascript/components/batch_update/components/SearchForm.js
+++ b/app/javascript/components/batch_update/components/SearchForm.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import copy from 'copy-to-clipboard'
 import styled from 'styled-components'
 import CurrentCriteria from './CurrentCriteria'
@@ -180,6 +180,8 @@ const HelixButton = ({ selectedArtworkIds }) => {
 }
 
 const CopyIdsToClipboard = ({ selectedArtworkIds, ...props }) => {
+  const [clicked, setClicked] = useState(false)
+
   return (
     <Button
       width="50%"
@@ -187,13 +189,17 @@ const CopyIdsToClipboard = ({ selectedArtworkIds, ...props }) => {
       size="small"
       variant="secondaryGray"
       onClick={() => {
+        setClicked(true)
+        setTimeout(() => {
+          setClicked(false)
+        }, 1000)
         event.preventDefault()
         copy(selectedArtworkIds)
         return false
       }}
       {...props}
     >
-      Copy IDs
+      Copy IDs {clicked && '✔'}
     </Button>
   )
 }

--- a/app/javascript/components/batch_update/components/SearchForm.js
+++ b/app/javascript/components/batch_update/components/SearchForm.js
@@ -14,6 +14,7 @@ import {
   TagAutosuggest,
 } from './Autosuggest'
 import FilterOptions from './FilterOptions'
+import { SortOptions } from './SortOptions'
 import { Button } from '@artsy/palette'
 import { Link } from './Links'
 import { SitesConsumer } from '../SitesContext'
@@ -69,6 +70,7 @@ class SearchForm extends React.Component {
       onRemoveTag,
       onRemoveArtist,
       partner,
+      sort,
       tags,
     } = this.props
 
@@ -137,6 +139,9 @@ class SearchForm extends React.Component {
           maxPrice={maxPrice}
           updateState={updateState}
         />
+
+        <SortOptions sort={sort} updateState={updateState} />
+
         <FilterOptions
           acquireableOrOfferableFilter={acquireableOrOfferableFilter}
           forSaleFilter={forSaleFilter}

--- a/app/javascript/components/batch_update/components/SearchForm.js
+++ b/app/javascript/components/batch_update/components/SearchForm.js
@@ -15,8 +15,7 @@ import {
 } from './Autosuggest'
 import FilterOptions from './FilterOptions'
 import { SortOptions } from './SortOptions'
-import { Button } from '@artsy/palette'
-import { Link } from './Links'
+import { Button, Flex } from '@artsy/palette'
 import { SitesConsumer } from '../SitesContext'
 
 class SearchForm extends React.Component {
@@ -46,8 +45,10 @@ class SearchForm extends React.Component {
           <Button width={1} onClick={onOpenBatchUpdate}>
             Edit Artworks
           </Button>
-          <HelixLink selectedArtworkIds={selectedArtworkIds} />
-          <CopyIdsToClipboard mt={1} selectedArtworkIds={selectedArtworkIds} />
+          <Flex mt={2} justifyContent="space-between">
+            <HelixButton selectedArtworkIds={selectedArtworkIds} />
+            <CopyIdsToClipboard selectedArtworkIds={selectedArtworkIds} />
+          </Flex>
         </>
       )
     }
@@ -155,7 +156,7 @@ class SearchForm extends React.Component {
   }
 }
 
-const HelixLink = ({ selectedArtworkIds }) => {
+const HelixButton = ({ selectedArtworkIds }) => {
   return (
     <SitesConsumer>
       {sites => {
@@ -163,9 +164,15 @@ const HelixLink = ({ selectedArtworkIds }) => {
           sites.helix
         }/genome/artworks?artwork_ids=${selectedArtworkIds.join(',')}`
         return (
-          <StyledLink target="_blank" rel="noopener noreferrer" href={href}>
-            Open selected works in Helix
-          </StyledLink>
+          <Button
+            width="50%"
+            mr={1}
+            size="small"
+            variant="secondaryGray"
+            onClick={() => window.open(href)}
+          >
+            Open in Helix
+          </Button>
         )
       }}
     </SitesConsumer>
@@ -175,6 +182,9 @@ const HelixLink = ({ selectedArtworkIds }) => {
 const CopyIdsToClipboard = ({ selectedArtworkIds, ...props }) => {
   return (
     <Button
+      width="50%"
+      ml={1}
+      size="small"
       variant="secondaryGray"
       onClick={() => {
         event.preventDefault()
@@ -183,15 +193,10 @@ const CopyIdsToClipboard = ({ selectedArtworkIds, ...props }) => {
       }}
       {...props}
     >
-      Copy selected works to clipboard
+      Copy IDs
     </Button>
   )
 }
-
-const StyledLink = styled(Link)`
-  display: block;
-  margin-top: 1em;
-`
 
 /* default styled component */
 

--- a/app/javascript/components/batch_update/components/SearchForm.spec.js
+++ b/app/javascript/components/batch_update/components/SearchForm.spec.js
@@ -141,7 +141,7 @@ describe('"edit artworks" button', () => {
   })
 })
 
-describe('Link to open artworks in Helix', () => {
+describe('Links to copy ids/open artworks in Helix', () => {
   it('does NOT render if there are NO selected artworks', () => {
     Object.assign(props, {
       artworksCount: 100,
@@ -149,8 +149,8 @@ describe('Link to open artworks in Helix', () => {
       selectedArtworkIds: [],
     })
     const wrapper = mount(<SearchForm {...props} />)
-    expect(wrapper.text()).not.toMatch(/open.*in Helix/i)
-    expect(wrapper.find('a[href*="helix"]')).toHaveLength(0)
+    expect(wrapper.text()).not.toMatch(/Open in Helix/i)
+    expect(wrapper.text()).not.toMatch(/Copy IDs/i)
   })
 
   it('renders if there are selected artworks', () => {
@@ -160,7 +160,7 @@ describe('Link to open artworks in Helix', () => {
       selectedArtworkIds: ['foo'],
     })
     const wrapper = mount(<SearchForm {...props} />)
-    expect(wrapper.text()).toMatch(/open.*in Helix/i)
-    expect(wrapper.find('a[href*="helix"]')).toHaveLength(1)
+    expect(wrapper.text()).toMatch(/Open in Helix/i)
+    expect(wrapper.text()).toMatch(/Copy IDs/i)
   })
 })

--- a/app/javascript/components/batch_update/components/SortOptions.js
+++ b/app/javascript/components/batch_update/components/SortOptions.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import { SelectSmall, Box } from '@artsy/palette'
+
+export const SortOptions = props => {
+  const { sort, updateState } = props
+
+  return (
+    <Box mt={2}>
+      <SelectSmall
+        title="Sort"
+        options={[
+          {
+            text: 'Merchandisability',
+            value: 'MERCHANDISABILITY',
+          },
+          { text: 'Recently published', value: 'RECENTLY_PUBLISHED' },
+        ]}
+        selected={sort}
+        onSelect={value => {
+          updateState('sort', value)
+        }}
+      />
+    </Box>
+  )
+}

--- a/app/javascript/components/batch_update/components/SortOptions.spec.js
+++ b/app/javascript/components/batch_update/components/SortOptions.spec.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { SortOptions } from './SortOptions'
+
+it('defaults to the current sort', () => {
+  const wrapper = mount(<SortOptions sort="RECENTLY_PUBLISHED" />)
+  const select = wrapper.find('select')
+  expect(select.prop('value')).toEqual('RECENTLY_PUBLISHED')
+})
+
+it("updates the app's sort state when a new value is selected", () => {
+  const updater = jest.fn()
+  const wrapper = mount(<SortOptions updateState={updater} />)
+  const select = wrapper.find('select')
+  const option = wrapper.find('option').last()
+  select.simulate('change', { target: option })
+  expect(updater).toHaveBeenCalled()
+})

--- a/app/javascript/components/batch_update/components/__snapshots__/App.spec.js.snap
+++ b/app/javascript/components/batch_update/components/__snapshots__/App.spec.js.snap
@@ -25,7 +25,7 @@ exports[`renders correctly 1`] = `
   padding: 1em;
 }
 
-.c8 {
+.c11 {
   -webkit-box-flex: 5;
   -webkit-flex-grow: 5;
   -ms-flex-positive: 5;
@@ -77,7 +77,7 @@ exports[`renders correctly 1`] = `
   outline: none;
 }
 
-.c5 {
+.c8 {
   font-size: 80%;
   color: #333;
   line-height: 140%;
@@ -87,22 +87,22 @@ exports[`renders correctly 1`] = `
   transition: opacity 0.5s;
 }
 
-.c5:hover {
+.c8:hover {
   opacity: 1;
   -webkit-transition: opacity 0.5s;
   transition: opacity 0.5s;
 }
 
-.c5 .filter {
+.c8 .filter {
   margin-top: 1em;
 }
 
-.c5 .filter a {
+.c8 .filter a {
   color: #999;
   margin-right: 0.5em;
 }
 
-.c5 .filter a.active {
+.c8 .filter a.active {
   color: #333;
   font-weight: bold;
   -webkit-text-decoration: none;
@@ -110,7 +110,19 @@ exports[`renders correctly 1`] = `
   cursor: default;
 }
 
+.c5 {
+  margin-top: 8px;
+}
+
 .c7 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 12px;
+  line-height: 16px;
+  display: inline;
+  margin-right: 0.5px;
+}
+
+.c10 {
   font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-size: 14px;
@@ -118,7 +130,7 @@ exports[`renders correctly 1`] = `
   padding-top: 1px;
 }
 
-.c15 {
+.c18 {
   font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
   font-size: 28px;
   line-height: 36px;
@@ -126,7 +138,7 @@ exports[`renders correctly 1`] = `
   margin-top: 16px;
 }
 
-.c17 {
+.c20 {
   font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
   font-size: 28px;
   line-height: 36px;
@@ -134,7 +146,7 @@ exports[`renders correctly 1`] = `
   margin-top: 32px;
 }
 
-.c6 {
+.c9 {
   cursor: pointer;
   position: relative;
   white-space: nowrap;
@@ -151,7 +163,7 @@ exports[`renders correctly 1`] = `
   color: #FFF;
 }
 
-.c6.loading {
+.c9.loading {
   -webkit-transition: none;
   transition: none;
   background-color: transparent;
@@ -160,14 +172,14 @@ exports[`renders correctly 1`] = `
   cursor: auto;
 }
 
-.c6.disabled {
+.c9.disabled {
   background-color: #E5E5E5;
   border-color: #E5E5E5;
   color: #FFF;
   pointer-events: none;
 }
 
-.c14 {
+.c17 {
   cursor: pointer;
   position: relative;
   white-space: nowrap;
@@ -183,7 +195,7 @@ exports[`renders correctly 1`] = `
   color: #FFF;
 }
 
-.c14.loading {
+.c17.loading {
   -webkit-transition: none;
   transition: none;
   background-color: transparent;
@@ -192,14 +204,14 @@ exports[`renders correctly 1`] = `
   cursor: auto;
 }
 
-.c14.disabled {
+.c17.disabled {
   background-color: #E5E5E5;
   border-color: #E5E5E5;
   color: #FFF;
   pointer-events: none;
 }
 
-.c20 {
+.c23 {
   cursor: pointer;
   position: relative;
   white-space: nowrap;
@@ -217,7 +229,7 @@ exports[`renders correctly 1`] = `
   color: #000;
 }
 
-.c20.loading {
+.c23.loading {
   -webkit-transition: none;
   transition: none;
   background-color: transparent;
@@ -226,18 +238,74 @@ exports[`renders correctly 1`] = `
   cursor: auto;
 }
 
-.c20.disabled {
+.c23.disabled {
   background-color: #E5E5E5;
   border-color: #E5E5E5;
   color: #FFF;
   pointer-events: none;
 }
 
-.c13 {
+.c6 {
+  position: relative;
+}
+
+.c6 label {
+  padding: 0;
+  margin: 0;
+}
+
+.c6 select {
+  background: none;
+  border: none;
+  cursor: pointer;
+  outline: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  text-indent: 0.01px;
+  text-overflow: "";
+  background-color: #E5E5E5;
+  border-radius: 2px;
+  font-size: px;
+  line-height: px;
+  padding: 5px 26px 5px 10px;
+}
+
+.c6 select:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
+.c6 select option:not(:checked) {
+  color: black;
+}
+
+.c6 select:hover {
+  background-color: #C2C2C2;
+}
+
+.c6 select:focus {
+  border-color: #6E1EFF;
+}
+
+.c6::after {
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 4px solid #000;
+  width: 0;
+  height: 0;
+  content: "";
+  cursor: pointer;
+  margin-left: -18px;
+  pointer-events: none;
+  position: absolute;
+  top: 10px;
+}
+
+.c16 {
   color: #666666;
 }
 
-.c9 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -247,24 +315,24 @@ exports[`renders correctly 1`] = `
   flex-direction: column;
 }
 
-.c9 .counts {
+.c12 .counts {
   display: inline-block;
   width: 75%;
   padding: 0.75em;
 }
 
-.c9 .select {
+.c12 .select {
   display: inline-block;
   width: 25%;
   padding: 0.75em;
   text-align: right;
 }
 
-.c9 .select a {
+.c12 .select a {
   margin: 0 0.25em;
 }
 
-.c9 .results {
+.c12 .results {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -274,7 +342,7 @@ exports[`renders correctly 1`] = `
   flex-flow: row wrap;
 }
 
-.c18 {
+.c21 {
   position: fixed;
   left: 50%;
   top: 40%;
@@ -292,7 +360,7 @@ exports[`renders correctly 1`] = `
   transition: all 0.25s;
 }
 
-.c18.modal-open {
+.c21.modal-open {
   visibility: visible;
   opacity: 1;
   -webkit-transform: scale(1) translate(-50%,-50%);
@@ -302,24 +370,24 @@ exports[`renders correctly 1`] = `
   transition: all 0.125s;
 }
 
-.c18 h1 {
+.c21 h1 {
   font-weight: normal;
   font-size: 1.5em;
   color: #666666;
 }
 
-.c18 section {
+.c21 section {
   color: #333333;
   border-top: solid 1px #E5E5E5;
   margin-top: 1em;
   padding-top: 1em;
 }
 
-.c18 section p {
+.c21 section p {
   margin-bottom: 1em;
 }
 
-.c19 {
+.c22 {
   border-top: solid 1px #E5E5E5;
   margin-top: 1em;
   padding-top: 1em;
@@ -336,15 +404,15 @@ exports[`renders correctly 1`] = `
   justify-content: flex-end;
 }
 
-.c19 a {
+.c22 a {
   margin-left: 1em;
 }
 
-.c11 {
+.c14 {
   padding: 18px 30px;
 }
 
-.c12 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -364,14 +432,14 @@ exports[`renders correctly 1`] = `
   border-bottom: solid 1px #DBDBDB;
 }
 
-.c16 {
+.c19 {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
   text-align: center;
 }
 
-.c10 {
+.c13 {
   position: fixed;
   left: 0px;
   top: 0px;
@@ -388,7 +456,7 @@ exports[`renders correctly 1`] = `
   transition: all 0.25s;
 }
 
-.c10.modal-open {
+.c13.modal-open {
   visibility: visible;
   opacity: 1;
   -webkit-transform: scale(1);
@@ -398,7 +466,7 @@ exports[`renders correctly 1`] = `
   transition: all 0.125s;
 }
 
-.c21 {
+.c24 {
   position: fixed;
   top: 0;
   right: 0;
@@ -424,7 +492,7 @@ exports[`renders correctly 1`] = `
 }
 
 @media not all and (pointer:coarse),not all and (-moz-touch-enabled:1) {
-  .c6:hover {
+  .c9:hover {
     background-color: #6E1EFF;
     border-color: #6E1EFF;
     color: #FFF;
@@ -432,7 +500,7 @@ exports[`renders correctly 1`] = `
 }
 
 @media not all and (pointer:coarse),not all and (-moz-touch-enabled:1) {
-  .c14:hover {
+  .c17:hover {
     background-color: #6E1EFF;
     border-color: #6E1EFF;
     color: #FFF;
@@ -440,7 +508,7 @@ exports[`renders correctly 1`] = `
 }
 
 @media not all and (pointer:coarse),not all and (-moz-touch-enabled:1) {
-  .c20:hover {
+  .c23:hover {
     background-color: #FFF;
     border-color: #000;
     color: #000;
@@ -716,6 +784,43 @@ exports[`renders correctly 1`] = `
         className="c5"
       >
         <div
+          className="c6"
+          onSelect={[Function]}
+          selected="RECENTLY_PUBLISHED"
+          title="Sort"
+        >
+          <label>
+            <div
+              className="c7 "
+              display="inline"
+              fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+              fontSize="12px"
+            >
+              Sort
+              :
+            </div>
+            <select
+              onChange={[Function]}
+              value="RECENTLY_PUBLISHED"
+            >
+              <option
+                value="MERCHANDISABILITY"
+              >
+                Merchandisability
+              </option>
+              <option
+                value="RECENTLY_PUBLISHED"
+              >
+                Recently published
+              </option>
+            </select>
+          </label>
+        </div>
+      </div>
+      <div
+        className="c8"
+      >
+        <div
           className="filter"
         >
           <div>
@@ -801,14 +906,14 @@ exports[`renders correctly 1`] = `
         </div>
       </div>
       <button
-        className="c6  disabled"
+        className="c9  disabled"
         disabled={true}
         height="41px"
         onClick={[Function]}
         width={1}
       >
         <div
-          className="c7 "
+          className="c10 "
           fontFamily={
             Object {
               "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -823,10 +928,10 @@ exports[`renders correctly 1`] = `
     </div>
   </div>
   <div
-    className="c8"
+    className="c11"
   >
     <div
-      className="c9"
+      className="c12"
     >
       <div
         className="results"
@@ -834,16 +939,16 @@ exports[`renders correctly 1`] = `
     </div>
   </div>
   <div
-    className="c10"
+    className="c13"
   >
     <div
-      className="c11"
+      className="c14"
     >
       <div
-        className="c12"
+        className="c15"
       >
         <a
-          className="c13 cancel"
+          className="c16 cancel"
           href="#"
           onClick={[Function]}
         >
@@ -854,13 +959,13 @@ exports[`renders correctly 1`] = `
            works selected
         </div>
         <button
-          className="c14  disabled"
+          className="c17  disabled"
           disabled={true}
           height="41px"
           onClick={[Function]}
         >
           <div
-            className="c7 "
+            className="c10 "
             fontFamily={
               Object {
                 "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -874,14 +979,14 @@ exports[`renders correctly 1`] = `
         </button>
       </div>
       <div
-        className="c15 "
+        className="c18 "
         fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
         fontSize="28px"
       >
         Tags
       </div>
       <div
-        className="c16"
+        className="c19"
       >
         There aren’t any tags that describe all of your selected works
       </div>
@@ -917,14 +1022,14 @@ exports[`renders correctly 1`] = `
         </div>
       </div>
       <div
-        className="c17 "
+        className="c20 "
         fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
         fontSize="28px"
       >
         Genes
       </div>
       <div
-        className="c16"
+        className="c19"
       >
         There aren’t any genes that describe all of your selected works
       </div>
@@ -960,7 +1065,7 @@ exports[`renders correctly 1`] = `
         </div>
       </div>
       <div
-        className="c18"
+        className="c21"
       >
         <h1>
           Are you sure you want to queue these changes?
@@ -974,15 +1079,15 @@ exports[`renders correctly 1`] = `
           </p>
         </section>
         <div
-          className="c19"
+          className="c22"
         >
           <button
-            className="c20  "
+            className="c23  "
             height="41px"
             onClick={[Function]}
           >
             <div
-              className="c7 "
+              className="c10 "
               fontFamily={
                 Object {
                   "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -995,12 +1100,12 @@ exports[`renders correctly 1`] = `
             </div>
           </button>
           <button
-            className="c14  "
+            className="c17  "
             height="41px"
             onClick={[Function]}
           >
             <div
-              className="c7 "
+              className="c10 "
               fontFamily={
                 Object {
                   "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -1017,7 +1122,7 @@ exports[`renders correctly 1`] = `
     </div>
   </div>
   <div
-    className="c21"
+    className="c24"
   />
 </div>
 `;

--- a/app/javascript/components/batch_update/components/__snapshots__/SearchForm.spec.js.snap
+++ b/app/javascript/components/batch_update/components/__snapshots__/SearchForm.spec.js.snap
@@ -42,7 +42,7 @@ exports[`"edit artworks" button does not render an edit button if there are no a
   outline: none;
 }
 
-.c3 {
+.c6 {
   font-size: 80%;
   color: #333;
   line-height: 140%;
@@ -52,27 +52,95 @@ exports[`"edit artworks" button does not render an edit button if there are no a
   transition: opacity 0.5s;
 }
 
-.c3:hover {
+.c6:hover {
   opacity: 1;
   -webkit-transition: opacity 0.5s;
   transition: opacity 0.5s;
 }
 
-.c3 .filter {
+.c6 .filter {
   margin-top: 1em;
 }
 
-.c3 .filter a {
+.c6 .filter a {
   color: #999;
   margin-right: 0.5em;
 }
 
-.c3 .filter a.active {
+.c6 .filter a.active {
   color: #333;
   font-weight: bold;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: default;
+}
+
+.c3 {
+  margin-top: 8px;
+}
+
+.c5 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 12px;
+  line-height: 16px;
+  display: inline;
+  margin-right: 0.5px;
+}
+
+.c4 {
+  position: relative;
+}
+
+.c4 label {
+  padding: 0;
+  margin: 0;
+}
+
+.c4 select {
+  background: none;
+  border: none;
+  cursor: pointer;
+  outline: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  text-indent: 0.01px;
+  text-overflow: "";
+  background-color: #E5E5E5;
+  border-radius: 2px;
+  font-size: px;
+  line-height: px;
+  padding: 5px 26px 5px 10px;
+}
+
+.c4 select:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
+.c4 select option:not(:checked) {
+  color: black;
+}
+
+.c4 select:hover {
+  background-color: #C2C2C2;
+}
+
+.c4 select:focus {
+  border-color: #6E1EFF;
+}
+
+.c4::after {
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 4px solid #000;
+  width: 0;
+  height: 0;
+  content: "";
+  cursor: pointer;
+  margin-left: -18px;
+  pointer-events: none;
+  position: absolute;
+  top: 10px;
 }
 
 <div
@@ -336,6 +404,41 @@ exports[`"edit artworks" button does not render an edit button if there are no a
   </div>
   <div
     className="c3"
+  >
+    <div
+      className="c4"
+      onSelect={[Function]}
+      title="Sort"
+    >
+      <label>
+        <div
+          className="c5 "
+          display="inline"
+          fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+          fontSize="12px"
+        >
+          Sort
+          :
+        </div>
+        <select
+          onChange={[Function]}
+        >
+          <option
+            value="MERCHANDISABILITY"
+          >
+            Merchandisability
+          </option>
+          <option
+            value="RECENTLY_PUBLISHED"
+          >
+            Recently published
+          </option>
+        </select>
+      </label>
+    </div>
+  </div>
+  <div
+    className="c6"
   >
     <div
       className="filter"
@@ -467,7 +570,7 @@ exports[`"edit artworks" button renders a disabled edit button if there are artw
   outline: none;
 }
 
-.c3 {
+.c6 {
   font-size: 80%;
   color: #333;
   line-height: 140%;
@@ -477,22 +580,22 @@ exports[`"edit artworks" button renders a disabled edit button if there are artw
   transition: opacity 0.5s;
 }
 
-.c3:hover {
+.c6:hover {
   opacity: 1;
   -webkit-transition: opacity 0.5s;
   transition: opacity 0.5s;
 }
 
-.c3 .filter {
+.c6 .filter {
   margin-top: 1em;
 }
 
-.c3 .filter a {
+.c6 .filter a {
   color: #999;
   margin-right: 0.5em;
 }
 
-.c3 .filter a.active {
+.c6 .filter a.active {
   color: #333;
   font-weight: bold;
   -webkit-text-decoration: none;
@@ -500,7 +603,19 @@ exports[`"edit artworks" button renders a disabled edit button if there are artw
   cursor: default;
 }
 
+.c3 {
+  margin-top: 8px;
+}
+
 .c5 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 12px;
+  line-height: 16px;
+  display: inline;
+  margin-right: 0.5px;
+}
+
+.c8 {
   font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-size: 14px;
@@ -508,7 +623,7 @@ exports[`"edit artworks" button renders a disabled edit button if there are artw
   padding-top: 1px;
 }
 
-.c4 {
+.c7 {
   cursor: pointer;
   position: relative;
   white-space: nowrap;
@@ -525,7 +640,7 @@ exports[`"edit artworks" button renders a disabled edit button if there are artw
   color: #FFF;
 }
 
-.c4.loading {
+.c7.loading {
   -webkit-transition: none;
   transition: none;
   background-color: transparent;
@@ -534,15 +649,71 @@ exports[`"edit artworks" button renders a disabled edit button if there are artw
   cursor: auto;
 }
 
-.c4.disabled {
+.c7.disabled {
   background-color: #E5E5E5;
   border-color: #E5E5E5;
   color: #FFF;
   pointer-events: none;
 }
 
+.c4 {
+  position: relative;
+}
+
+.c4 label {
+  padding: 0;
+  margin: 0;
+}
+
+.c4 select {
+  background: none;
+  border: none;
+  cursor: pointer;
+  outline: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  text-indent: 0.01px;
+  text-overflow: "";
+  background-color: #E5E5E5;
+  border-radius: 2px;
+  font-size: px;
+  line-height: px;
+  padding: 5px 26px 5px 10px;
+}
+
+.c4 select:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
+.c4 select option:not(:checked) {
+  color: black;
+}
+
+.c4 select:hover {
+  background-color: #C2C2C2;
+}
+
+.c4 select:focus {
+  border-color: #6E1EFF;
+}
+
+.c4::after {
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 4px solid #000;
+  width: 0;
+  height: 0;
+  content: "";
+  cursor: pointer;
+  margin-left: -18px;
+  pointer-events: none;
+  position: absolute;
+  top: 10px;
+}
+
 @media not all and (pointer:coarse),not all and (-moz-touch-enabled:1) {
-  .c4:hover {
+  .c7:hover {
     background-color: #6E1EFF;
     border-color: #6E1EFF;
     color: #FFF;
@@ -812,6 +983,41 @@ exports[`"edit artworks" button renders a disabled edit button if there are artw
     className="c3"
   >
     <div
+      className="c4"
+      onSelect={[Function]}
+      title="Sort"
+    >
+      <label>
+        <div
+          className="c5 "
+          display="inline"
+          fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+          fontSize="12px"
+        >
+          Sort
+          :
+        </div>
+        <select
+          onChange={[Function]}
+        >
+          <option
+            value="MERCHANDISABILITY"
+          >
+            Merchandisability
+          </option>
+          <option
+            value="RECENTLY_PUBLISHED"
+          >
+            Recently published
+          </option>
+        </select>
+      </label>
+    </div>
+  </div>
+  <div
+    className="c6"
+  >
+    <div
       className="filter"
     >
       <div>
@@ -897,14 +1103,14 @@ exports[`"edit artworks" button renders a disabled edit button if there are artw
     </div>
   </div>
   <button
-    className="c4  disabled"
+    className="c7  disabled"
     disabled={true}
     height="41px"
     onClick={[Function]}
     width={1}
   >
     <div
-      className="c5 "
+      className="c8 "
       fontFamily={
         Object {
           "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -961,7 +1167,7 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
   outline: none;
 }
 
-.c3 {
+.c6 {
   font-size: 80%;
   color: #333;
   line-height: 140%;
@@ -971,22 +1177,22 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
   transition: opacity 0.5s;
 }
 
-.c3:hover {
+.c6:hover {
   opacity: 1;
   -webkit-transition: opacity 0.5s;
   transition: opacity 0.5s;
 }
 
-.c3 .filter {
+.c6 .filter {
   margin-top: 1em;
 }
 
-.c3 .filter a {
+.c6 .filter a {
   color: #999;
   margin-right: 0.5em;
 }
 
-.c3 .filter a.active {
+.c6 .filter a.active {
   color: #333;
   font-weight: bold;
   -webkit-text-decoration: none;
@@ -994,7 +1200,19 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
   cursor: default;
 }
 
+.c3 {
+  margin-top: 8px;
+}
+
 .c5 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 12px;
+  line-height: 16px;
+  display: inline;
+  margin-right: 0.5px;
+}
+
+.c8 {
   font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-size: 14px;
@@ -1002,7 +1220,7 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
   padding-top: 1px;
 }
 
-.c4 {
+.c7 {
   cursor: pointer;
   position: relative;
   white-space: nowrap;
@@ -1017,39 +1235,6 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
   background-color: #000;
   border-color: #000;
   color: #FFF;
-}
-
-.c4.loading {
-  -webkit-transition: none;
-  transition: none;
-  background-color: transparent;
-  color: transparent;
-  border: 0;
-  cursor: auto;
-}
-
-.c4.disabled {
-  background-color: #E5E5E5;
-  border-color: #E5E5E5;
-  color: #FFF;
-  pointer-events: none;
-}
-
-.c7 {
-  cursor: pointer;
-  position: relative;
-  white-space: nowrap;
-  border: 2px solid;
-  border-radius: 3px;
-  margin-top: 10px;
-  padding-left: 20px;
-  padding-right: 20px;
-  height: 41px;
-  -webkit-transition: 0.25s ease;
-  transition: 0.25s ease;
-  background-color: #E5E5E5;
-  border-color: #E5E5E5;
-  color: #000;
 }
 
 .c7.loading {
@@ -1068,14 +1253,103 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
   pointer-events: none;
 }
 
-.c6 {
+.c10 {
+  cursor: pointer;
+  position: relative;
+  white-space: nowrap;
+  border: 2px solid;
+  border-radius: 3px;
+  margin-top: 10px;
+  padding-left: 20px;
+  padding-right: 20px;
+  height: 41px;
+  -webkit-transition: 0.25s ease;
+  transition: 0.25s ease;
+  background-color: #E5E5E5;
+  border-color: #E5E5E5;
+  color: #000;
+}
+
+.c10.loading {
+  -webkit-transition: none;
+  transition: none;
+  background-color: transparent;
+  color: transparent;
+  border: 0;
+  cursor: auto;
+}
+
+.c10.disabled {
+  background-color: #E5E5E5;
+  border-color: #E5E5E5;
+  color: #FFF;
+  pointer-events: none;
+}
+
+.c4 {
+  position: relative;
+}
+
+.c4 label {
+  padding: 0;
+  margin: 0;
+}
+
+.c4 select {
+  background: none;
+  border: none;
+  cursor: pointer;
+  outline: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  text-indent: 0.01px;
+  text-overflow: "";
+  background-color: #E5E5E5;
+  border-radius: 2px;
+  font-size: px;
+  line-height: px;
+  padding: 5px 26px 5px 10px;
+}
+
+.c4 select:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
+.c4 select option:not(:checked) {
+  color: black;
+}
+
+.c4 select:hover {
+  background-color: #C2C2C2;
+}
+
+.c4 select:focus {
+  border-color: #6E1EFF;
+}
+
+.c4::after {
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 4px solid #000;
+  width: 0;
+  height: 0;
+  content: "";
+  cursor: pointer;
+  margin-left: -18px;
+  pointer-events: none;
+  position: absolute;
+  top: 10px;
+}
+
+.c9 {
   color: #666666;
   display: block;
   margin-top: 1em;
 }
 
 @media not all and (pointer:coarse),not all and (-moz-touch-enabled:1) {
-  .c4:hover {
+  .c7:hover {
     background-color: #6E1EFF;
     border-color: #6E1EFF;
     color: #FFF;
@@ -1083,7 +1357,7 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
 }
 
 @media not all and (pointer:coarse),not all and (-moz-touch-enabled:1) {
-  .c7:hover {
+  .c10:hover {
     background-color: #C2C2C2;
     border-color: #C2C2C2;
     color: #000;
@@ -1353,6 +1627,41 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
     className="c3"
   >
     <div
+      className="c4"
+      onSelect={[Function]}
+      title="Sort"
+    >
+      <label>
+        <div
+          className="c5 "
+          display="inline"
+          fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+          fontSize="12px"
+        >
+          Sort
+          :
+        </div>
+        <select
+          onChange={[Function]}
+        >
+          <option
+            value="MERCHANDISABILITY"
+          >
+            Merchandisability
+          </option>
+          <option
+            value="RECENTLY_PUBLISHED"
+          >
+            Recently published
+          </option>
+        </select>
+      </label>
+    </div>
+  </div>
+  <div
+    className="c6"
+  >
+    <div
       className="filter"
     >
       <div>
@@ -1438,13 +1747,13 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
     </div>
   </div>
   <button
-    className="c4  "
+    className="c7  "
     height="41px"
     onClick={[Function]}
     width={1}
   >
     <div
-      className="c5 "
+      className="c8 "
       fontFamily={
         Object {
           "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -1457,7 +1766,7 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
     </div>
   </button>
   <a
-    className="c6"
+    className="c9"
     href="http://helix/genome/artworks?artwork_ids="
     rel="noopener noreferrer"
     target="_blank"
@@ -1465,12 +1774,12 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
     Open selected works in Helix
   </a>
   <button
-    className="c7  "
+    className="c10  "
     height="41px"
     onClick={[Function]}
   >
     <div
-      className="c5 "
+      className="c8 "
       fontFamily={
         Object {
           "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -1551,7 +1860,7 @@ exports[`does not render attribution class autosuggest if it is already selected
   outline: none;
 }
 
-.c4 {
+.c7 {
   font-size: 80%;
   color: #333;
   line-height: 140%;
@@ -1561,27 +1870,95 @@ exports[`does not render attribution class autosuggest if it is already selected
   transition: opacity 0.5s;
 }
 
-.c4:hover {
+.c7:hover {
   opacity: 1;
   -webkit-transition: opacity 0.5s;
   transition: opacity 0.5s;
 }
 
-.c4 .filter {
+.c7 .filter {
   margin-top: 1em;
 }
 
-.c4 .filter a {
+.c7 .filter a {
   color: #999;
   margin-right: 0.5em;
 }
 
-.c4 .filter a.active {
+.c7 .filter a.active {
   color: #333;
   font-weight: bold;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: default;
+}
+
+.c4 {
+  margin-top: 8px;
+}
+
+.c6 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 12px;
+  line-height: 16px;
+  display: inline;
+  margin-right: 0.5px;
+}
+
+.c5 {
+  position: relative;
+}
+
+.c5 label {
+  padding: 0;
+  margin: 0;
+}
+
+.c5 select {
+  background: none;
+  border: none;
+  cursor: pointer;
+  outline: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  text-indent: 0.01px;
+  text-overflow: "";
+  background-color: #E5E5E5;
+  border-radius: 2px;
+  font-size: px;
+  line-height: px;
+  padding: 5px 26px 5px 10px;
+}
+
+.c5 select:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
+.c5 select option:not(:checked) {
+  color: black;
+}
+
+.c5 select:hover {
+  background-color: #C2C2C2;
+}
+
+.c5 select:focus {
+  border-color: #6E1EFF;
+}
+
+.c5::after {
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 4px solid #000;
+  width: 0;
+  height: 0;
+  content: "";
+  cursor: pointer;
+  margin-left: -18px;
+  pointer-events: none;
+  position: absolute;
+  top: 10px;
 }
 
 <div
@@ -1834,6 +2211,41 @@ exports[`does not render attribution class autosuggest if it is already selected
     className="c4"
   >
     <div
+      className="c5"
+      onSelect={[Function]}
+      title="Sort"
+    >
+      <label>
+        <div
+          className="c6 "
+          display="inline"
+          fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+          fontSize="12px"
+        >
+          Sort
+          :
+        </div>
+        <select
+          onChange={[Function]}
+        >
+          <option
+            value="MERCHANDISABILITY"
+          >
+            Merchandisability
+          </option>
+          <option
+            value="RECENTLY_PUBLISHED"
+          >
+            Recently published
+          </option>
+        </select>
+      </label>
+    </div>
+  </div>
+  <div
+    className="c7"
+  >
+    <div
       className="filter"
     >
       <div>
@@ -1987,7 +2399,7 @@ exports[`does not render fair autosuggest if fair is already selected 1`] = `
   outline: none;
 }
 
-.c4 {
+.c7 {
   font-size: 80%;
   color: #333;
   line-height: 140%;
@@ -1997,27 +2409,95 @@ exports[`does not render fair autosuggest if fair is already selected 1`] = `
   transition: opacity 0.5s;
 }
 
-.c4:hover {
+.c7:hover {
   opacity: 1;
   -webkit-transition: opacity 0.5s;
   transition: opacity 0.5s;
 }
 
-.c4 .filter {
+.c7 .filter {
   margin-top: 1em;
 }
 
-.c4 .filter a {
+.c7 .filter a {
   color: #999;
   margin-right: 0.5em;
 }
 
-.c4 .filter a.active {
+.c7 .filter a.active {
   color: #333;
   font-weight: bold;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: default;
+}
+
+.c4 {
+  margin-top: 8px;
+}
+
+.c6 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 12px;
+  line-height: 16px;
+  display: inline;
+  margin-right: 0.5px;
+}
+
+.c5 {
+  position: relative;
+}
+
+.c5 label {
+  padding: 0;
+  margin: 0;
+}
+
+.c5 select {
+  background: none;
+  border: none;
+  cursor: pointer;
+  outline: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  text-indent: 0.01px;
+  text-overflow: "";
+  background-color: #E5E5E5;
+  border-radius: 2px;
+  font-size: px;
+  line-height: px;
+  padding: 5px 26px 5px 10px;
+}
+
+.c5 select:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
+.c5 select option:not(:checked) {
+  color: black;
+}
+
+.c5 select:hover {
+  background-color: #C2C2C2;
+}
+
+.c5 select:focus {
+  border-color: #6E1EFF;
+}
+
+.c5::after {
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 4px solid #000;
+  width: 0;
+  height: 0;
+  content: "";
+  cursor: pointer;
+  margin-left: -18px;
+  pointer-events: none;
+  position: absolute;
+  top: 10px;
 }
 
 <div
@@ -2270,6 +2750,41 @@ exports[`does not render fair autosuggest if fair is already selected 1`] = `
     className="c4"
   >
     <div
+      className="c5"
+      onSelect={[Function]}
+      title="Sort"
+    >
+      <label>
+        <div
+          className="c6 "
+          display="inline"
+          fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+          fontSize="12px"
+        >
+          Sort
+          :
+        </div>
+        <select
+          onChange={[Function]}
+        >
+          <option
+            value="MERCHANDISABILITY"
+          >
+            Merchandisability
+          </option>
+          <option
+            value="RECENTLY_PUBLISHED"
+          >
+            Recently published
+          </option>
+        </select>
+      </label>
+    </div>
+  </div>
+  <div
+    className="c7"
+  >
+    <div
       className="filter"
     >
       <div>
@@ -2423,7 +2938,7 @@ exports[`does not render partner autosuggest if partner is already selected 1`] 
   outline: none;
 }
 
-.c4 {
+.c7 {
   font-size: 80%;
   color: #333;
   line-height: 140%;
@@ -2433,27 +2948,95 @@ exports[`does not render partner autosuggest if partner is already selected 1`] 
   transition: opacity 0.5s;
 }
 
-.c4:hover {
+.c7:hover {
   opacity: 1;
   -webkit-transition: opacity 0.5s;
   transition: opacity 0.5s;
 }
 
-.c4 .filter {
+.c7 .filter {
   margin-top: 1em;
 }
 
-.c4 .filter a {
+.c7 .filter a {
   color: #999;
   margin-right: 0.5em;
 }
 
-.c4 .filter a.active {
+.c7 .filter a.active {
   color: #333;
   font-weight: bold;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: default;
+}
+
+.c4 {
+  margin-top: 8px;
+}
+
+.c6 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 12px;
+  line-height: 16px;
+  display: inline;
+  margin-right: 0.5px;
+}
+
+.c5 {
+  position: relative;
+}
+
+.c5 label {
+  padding: 0;
+  margin: 0;
+}
+
+.c5 select {
+  background: none;
+  border: none;
+  cursor: pointer;
+  outline: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  text-indent: 0.01px;
+  text-overflow: "";
+  background-color: #E5E5E5;
+  border-radius: 2px;
+  font-size: px;
+  line-height: px;
+  padding: 5px 26px 5px 10px;
+}
+
+.c5 select:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
+.c5 select option:not(:checked) {
+  color: black;
+}
+
+.c5 select:hover {
+  background-color: #C2C2C2;
+}
+
+.c5 select:focus {
+  border-color: #6E1EFF;
+}
+
+.c5::after {
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 4px solid #000;
+  width: 0;
+  height: 0;
+  content: "";
+  cursor: pointer;
+  margin-left: -18px;
+  pointer-events: none;
+  position: absolute;
+  top: 10px;
 }
 
 <div
@@ -2706,6 +3289,41 @@ exports[`does not render partner autosuggest if partner is already selected 1`] 
     className="c4"
   >
     <div
+      className="c5"
+      onSelect={[Function]}
+      title="Sort"
+    >
+      <label>
+        <div
+          className="c6 "
+          display="inline"
+          fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+          fontSize="12px"
+        >
+          Sort
+          :
+        </div>
+        <select
+          onChange={[Function]}
+        >
+          <option
+            value="MERCHANDISABILITY"
+          >
+            Merchandisability
+          </option>
+          <option
+            value="RECENTLY_PUBLISHED"
+          >
+            Recently published
+          </option>
+        </select>
+      </label>
+    </div>
+  </div>
+  <div
+    className="c7"
+  >
+    <div
       className="filter"
     >
       <div>
@@ -2835,7 +3453,7 @@ exports[`renders correctly 1`] = `
   outline: none;
 }
 
-.c3 {
+.c6 {
   font-size: 80%;
   color: #333;
   line-height: 140%;
@@ -2845,27 +3463,95 @@ exports[`renders correctly 1`] = `
   transition: opacity 0.5s;
 }
 
-.c3:hover {
+.c6:hover {
   opacity: 1;
   -webkit-transition: opacity 0.5s;
   transition: opacity 0.5s;
 }
 
-.c3 .filter {
+.c6 .filter {
   margin-top: 1em;
 }
 
-.c3 .filter a {
+.c6 .filter a {
   color: #999;
   margin-right: 0.5em;
 }
 
-.c3 .filter a.active {
+.c6 .filter a.active {
   color: #333;
   font-weight: bold;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: default;
+}
+
+.c3 {
+  margin-top: 8px;
+}
+
+.c5 {
+  font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 12px;
+  line-height: 16px;
+  display: inline;
+  margin-right: 0.5px;
+}
+
+.c4 {
+  position: relative;
+}
+
+.c4 label {
+  padding: 0;
+  margin: 0;
+}
+
+.c4 select {
+  background: none;
+  border: none;
+  cursor: pointer;
+  outline: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  text-indent: 0.01px;
+  text-overflow: "";
+  background-color: #E5E5E5;
+  border-radius: 2px;
+  font-size: px;
+  line-height: px;
+  padding: 5px 26px 5px 10px;
+}
+
+.c4 select:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
+.c4 select option:not(:checked) {
+  color: black;
+}
+
+.c4 select:hover {
+  background-color: #C2C2C2;
+}
+
+.c4 select:focus {
+  border-color: #6E1EFF;
+}
+
+.c4::after {
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 4px solid #000;
+  width: 0;
+  height: 0;
+  content: "";
+  cursor: pointer;
+  margin-left: -18px;
+  pointer-events: none;
+  position: absolute;
+  top: 10px;
 }
 
 <div
@@ -3129,6 +3815,41 @@ exports[`renders correctly 1`] = `
   </div>
   <div
     className="c3"
+  >
+    <div
+      className="c4"
+      onSelect={[Function]}
+      title="Sort"
+    >
+      <label>
+        <div
+          className="c5 "
+          display="inline"
+          fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+          fontSize="12px"
+        >
+          Sort
+          :
+        </div>
+        <select
+          onChange={[Function]}
+        >
+          <option
+            value="MERCHANDISABILITY"
+          >
+            Merchandisability
+          </option>
+          <option
+            value="RECENTLY_PUBLISHED"
+          >
+            Recently published
+          </option>
+        </select>
+      </label>
+    </div>
+  </div>
+  <div
+    className="c6"
   >
     <div
       className="filter"

--- a/app/javascript/components/batch_update/components/__snapshots__/SearchForm.spec.js.snap
+++ b/app/javascript/components/batch_update/components/__snapshots__/SearchForm.spec.js.snap
@@ -1860,7 +1860,7 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
         }
         fontSize="12px"
       >
-        Copy IDs
+        Copy IDs 
       </div>
     </button>
   </div>

--- a/app/javascript/components/batch_update/components/__snapshots__/SearchForm.spec.js.snap
+++ b/app/javascript/components/batch_update/components/__snapshots__/SearchForm.spec.js.snap
@@ -1204,6 +1204,18 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
   margin-top: 8px;
 }
 
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin-top: 8px;
+}
+
 .c5 {
   font-family: Unica77LLWebRegular,'Helvetica Neue',Helvetica,Arial,sans-serif;
   font-size: 12px;
@@ -1217,6 +1229,14 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
   font-weight: 500;
   font-size: 14px;
   line-height: 20px;
+  padding-top: 1px;
+}
+
+.c11 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 12px;
+  line-height: 16px;
   padding-top: 1px;
 }
 
@@ -1259,10 +1279,11 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
   white-space: nowrap;
   border: 2px solid;
   border-radius: 3px;
-  margin-top: 10px;
+  margin-right: 10px;
   padding-left: 20px;
   padding-right: 20px;
-  height: 41px;
+  width: 50%;
+  height: 26px;
   -webkit-transition: 0.25s ease;
   transition: 0.25s ease;
   background-color: #E5E5E5;
@@ -1280,6 +1301,40 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
 }
 
 .c10.disabled {
+  background-color: #E5E5E5;
+  border-color: #E5E5E5;
+  color: #FFF;
+  pointer-events: none;
+}
+
+.c12 {
+  cursor: pointer;
+  position: relative;
+  white-space: nowrap;
+  border: 2px solid;
+  border-radius: 3px;
+  margin-left: 10px;
+  padding-left: 20px;
+  padding-right: 20px;
+  width: 50%;
+  height: 26px;
+  -webkit-transition: 0.25s ease;
+  transition: 0.25s ease;
+  background-color: #E5E5E5;
+  border-color: #E5E5E5;
+  color: #000;
+}
+
+.c12.loading {
+  -webkit-transition: none;
+  transition: none;
+  background-color: transparent;
+  color: transparent;
+  border: 0;
+  cursor: auto;
+}
+
+.c12.disabled {
   background-color: #E5E5E5;
   border-color: #E5E5E5;
   color: #FFF;
@@ -1342,12 +1397,6 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
   top: 10px;
 }
 
-.c9 {
-  color: #666666;
-  display: block;
-  margin-top: 1em;
-}
-
 @media not all and (pointer:coarse),not all and (-moz-touch-enabled:1) {
   .c7:hover {
     background-color: #6E1EFF;
@@ -1358,6 +1407,14 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
 
 @media not all and (pointer:coarse),not all and (-moz-touch-enabled:1) {
   .c10:hover {
+    background-color: #C2C2C2;
+    border-color: #C2C2C2;
+    color: #000;
+  }
+}
+
+@media not all and (pointer:coarse),not all and (-moz-touch-enabled:1) {
+  .c12:hover {
     background-color: #C2C2C2;
     border-color: #C2C2C2;
     color: #000;
@@ -1765,32 +1822,48 @@ exports[`"edit artworks" button renders an enabled edit button if there are sele
       Edit Artworks
     </div>
   </button>
-  <a
+  <div
     className="c9"
-    href="http://helix/genome/artworks?artwork_ids="
-    rel="noopener noreferrer"
-    target="_blank"
   >
-    Open selected works in Helix
-  </a>
-  <button
-    className="c10  "
-    height="41px"
-    onClick={[Function]}
-  >
-    <div
-      className="c8 "
-      fontFamily={
-        Object {
-          "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-          "fontWeight": 500,
-        }
-      }
-      fontSize="14px"
+    <button
+      className="c10  "
+      height="26px"
+      onClick={[Function]}
+      width="50%"
     >
-      Copy selected works to clipboard
-    </div>
-  </button>
+      <div
+        className="c11 "
+        fontFamily={
+          Object {
+            "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+            "fontWeight": 500,
+          }
+        }
+        fontSize="12px"
+      >
+        Open in Helix
+      </div>
+    </button>
+    <button
+      className="c12  "
+      height="26px"
+      onClick={[Function]}
+      width="50%"
+    >
+      <div
+        className="c11 "
+        fontFamily={
+          Object {
+            "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+            "fontWeight": 500,
+          }
+        }
+        fontSize="12px"
+      >
+        Copy IDs
+      </div>
+    </button>
+  </div>
 </div>
 `;
 

--- a/app/javascript/components/batch_update/helpers/elasticsearch.js
+++ b/app/javascript/components/batch_update/helpers/elasticsearch.js
@@ -1,6 +1,10 @@
 const defaultPageSize = 100
 const DEBUG = false
 
+const SORT_CLAUSES = {
+  RECENTLY_PUBLISHED: { published_at: 'desc' },
+}
+
 export function buildElasticsearchQuery(args) {
   const {
     acquireableOrOfferableFilter,
@@ -18,6 +22,7 @@ export function buildElasticsearchQuery(args) {
     partner,
     publishedFilter,
     size,
+    sort,
     tags,
   } = args
 
@@ -67,6 +72,8 @@ export function buildElasticsearchQuery(args) {
     }
   })
 
+  const sortClause = buildSort(sort)
+
   const query = {
     query: {
       bool: {
@@ -85,7 +92,7 @@ export function buildElasticsearchQuery(args) {
         ].filter(m => m !== null),
       },
     },
-    sort: [{ published_at: 'desc' }, { id: 'desc' }],
+    sort: sortClause,
     from: from || 0,
     size: size || defaultPageSize,
   }
@@ -116,6 +123,10 @@ const buildCreatedDateRange = ({ createdAfterDate, createdBeforeDate }) => {
   }
 
   return query
+}
+
+const buildSort = sort => {
+  return [SORT_CLAUSES[sort], { id: 'desc' }]
 }
 
 const buildFilterMatches = ({

--- a/app/javascript/components/batch_update/helpers/elasticsearch.js
+++ b/app/javascript/components/batch_update/helpers/elasticsearch.js
@@ -2,6 +2,7 @@ const defaultPageSize = 100
 const DEBUG = false
 
 const SORT_CLAUSES = {
+  MERCHANDISABILITY: { merchandisability: 'desc' },
   RECENTLY_PUBLISHED: { published_at: 'desc' },
 }
 

--- a/app/javascript/components/batch_update/helpers/elasticsearch.spec.js
+++ b/app/javascript/components/batch_update/helpers/elasticsearch.spec.js
@@ -516,4 +516,52 @@ describe('buildElasticsearchQuery', () => {
       expect(actualQuery).toEqual(expectedQuery)
     })
   })
+
+  describe('sort orders', () => {
+    beforeEach(() => {
+      params.genes = [{ id: 'gene1', name: 'Gene 1' }]
+    })
+
+    it('sorts by merchandisability', () => {
+      const expectedQuery = {
+        query: {
+          bool: {
+            must: [
+              { match: { deleted: false } },
+              { match: { 'genes.raw': 'Gene 1' } },
+            ],
+          },
+        },
+        from: 0,
+        size: 100,
+        sort: [{ merchandisability: 'desc' }, { id: 'desc' }],
+      }
+
+      params.sort = 'MERCHANDISABILITY'
+
+      const actualQuery = buildElasticsearchQuery(params)
+      expect(actualQuery).toEqual(expectedQuery)
+    })
+
+    it('sorts by publish date', () => {
+      const expectedQuery = {
+        query: {
+          bool: {
+            must: [
+              { match: { deleted: false } },
+              { match: { 'genes.raw': 'Gene 1' } },
+            ],
+          },
+        },
+        from: 0,
+        size: 100,
+        sort: [{ published_at: 'desc' }, { id: 'desc' }],
+      }
+
+      params.sort = 'RECENTLY_PUBLISHED'
+
+      const actualQuery = buildElasticsearchQuery(params)
+      expect(actualQuery).toEqual(expectedQuery)
+    })
+  })
 })

--- a/app/javascript/components/batch_update/helpers/elasticsearch.spec.js
+++ b/app/javascript/components/batch_update/helpers/elasticsearch.spec.js
@@ -17,6 +17,7 @@ describe('buildElasticsearchQuery', () => {
       minPrice: null,
       partner: null,
       publishedFilter: null,
+      sort: 'RECENTLY_PUBLISHED',
       tags: [],
     }
   })


### PR DESCRIPTION

This adds a form element that allows the artwork search results to be sorted by user preference.

Currently only "Recently published" and "Merchandisability" are required. With this pattern in place, others can be easily added (assuming the underlying fields are available in ES)

_(The first three commits are the gist of this PR. The latter two add some follow-ups to earlier PRs.)_

![sort](https://user-images.githubusercontent.com/140521/72109530-0c737380-3304-11ea-9fa8-fa5cb2b791a3.gif)

