### PR TITLE
Fix the "Load More" artworks button

### DIFF
--- a/app/javascript/components/batch_update/components/App.js
+++ b/app/javascript/components/batch_update/components/App.js
@@ -247,7 +247,9 @@ class App extends React.Component {
       tags,
     })
 
-    matchArtworks(query).then(hits => {
+    const csrfToken = document.querySelector('meta[name=csrf-token]').content
+
+    matchArtworks(query, csrfToken).then(hits => {
       const totalHits = hits.total
       const moreArtworks = hits.hits.map(hit => hit._source)
       this.setState({ artworks: [...artworks, ...moreArtworks], totalHits })


### PR DESCRIPTION
Otherwise happy users of the new hackathon features pointed out a bug. **Load More** doesn't work currently! 

This fixes that with a small follow-up to https://github.com/artsy/rosalind/pull/339/commits/423dacb3314b10036a02c17c3e7e1b12f3d05c89 to carry the same CSRF fix over to the `onLoadMore` action (which also now triggers the same POST instead of a GET).

cc @dblandin 