### PR TITLE
Update Postgres container auth settings

### DIFF
--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -15,3 +15,4 @@ services:
     image: postgres:9.6
     environment:
       - POSTGRES_DB=rosalind_test
+      - POSTGRES_HOST_AUTH_METHOD=trust


### PR DESCRIPTION
CI is currently failing, but should be working again after this fix.

Turns out that [recent changes](https://github.com/docker-library/postgres/pull/658/commits/42ce7437ee68150ee29f5272428aa4fc657dc6dc) in the Postgres Docker image require either (a) `POSTGRES_PASSWORD` to be set or (b) `POSTGRES_HOST_AUTH_METHOD` to be set to `trust`

I went with the latter, which seems safe for CI.

