### PR TITLE
Tune resource assignment based on observed use.

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -48,10 +48,10 @@ spec:
               containerPort: 8080
           resources:
             requests:
-              cpu: 300m
+              cpu: 200m
               memory: 256Mi
             limits:
-              memory: 500Mi
+              memory: 512Mi
           readinessProbe:
             httpGet:
               port: rosalind-http
@@ -214,7 +214,10 @@ spec:
             periodSeconds: 30
           resources:
             requests:
-              cpu: "0.5"
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -48,10 +48,10 @@ spec:
               containerPort: 8080
           resources:
             requests:
-              cpu: 200m
+              cpu: 100m
               memory: 256Mi
             limits:
-              memory: 500Mi
+              memory: 512Mi
           readinessProbe:
             httpGet:
               port: rosalind-http
@@ -118,7 +118,7 @@ spec:
     apiVersion: extensions/v1beta1
     kind: Deployment
     name: rosalind-web
-  minReplicas: 2
+  minReplicas: 1
   maxReplicas: 6
   targetCPUUtilizationPercentage: 70
 ---
@@ -214,7 +214,10 @@ spec:
             periodSeconds: 30
           resources:
             requests:
-              cpu: "0.5"
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/PLATFORM-2659

Prod
---
For Web:
- Reduce CPU request due to low usage. CPU usage is still allowed to burst, beyond request.

For Sidekiq:
- Reduce CPU request due to low usage. CPU usage is still allowed to burst, beyond request.
- It does not have memory req/limit setting. Here we are going to set them. Recommending 256M/512M.

Staging
---
Similar changes.

Resources
---
- Tuning guideline:
https://www.notion.so/artsy/Guidelines-on-tuning-an-app-s-CPU-and-memory-consumption-in-a-Kubernetes-cluster-797977be895643af84015a7d4b60a5dc
- Prod Web usage dashboard (please change filters to see other prod deployments or staging deployments).
https://app.datadoghq.com/dashboard/2n5-6tr-ypp/kubernetes-cpumemory-usage-by-deployment?from_ts=1594818315523&live=true&to_ts=1594991115523&tpl_var_container=rosalind-web&tpl_var_deployment=rosalind-web&tpl_var_env=production&tpl_var_hpa=rosalind-web&tv_mode=false