### PR TITLE
#migration Add Ingress resource in hokusai/staging.yml and hokusai/production.yml. Switch DNS to Ingress.

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -227,3 +227,40 @@ spec:
                     operator: In
                     values:
                       - background
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: rosalind
+    component: web
+    layer: application
+  name: rosalind-web-internal
+  namespace: default
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http
+      targetPort: 8080
+  selector:
+    app: rosalind
+    layer: application
+    component: web
+  type: ClusterIP
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: rosalind
+spec:
+  rules:
+    - host: n
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: rosalind-web-internal
+              servicePort: http

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -257,7 +257,7 @@ metadata:
   name: rosalind
 spec:
   rules:
-    - host: n
+    - host: rosalind.artsy.net
       http:
         paths:
           - path: /

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -227,3 +227,40 @@ spec:
                     operator: In
                     values:
                       - background
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: rosalind
+    component: web
+    layer: application
+  name: rosalind-web-internal
+  namespace: default
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http
+      targetPort: 8080
+  selector:
+    app: rosalind
+    layer: application
+    component: web
+  type: ClusterIP
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: rosalind
+spec:
+  rules:
+    - host: rosalind-staging.artsy.net
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: rosalind-web-internal
+              servicePort: http


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/PLATFORM-2610

See https://www.notion.so/artsy/Nginx-Ingress-Controllers-4b5d937f0acd480f938c34ef1509d3c4 and the section `Migrating an application from an external LoadBalancer-fronted service to an Ingress-fronted service`.

Migration Steps
---
1. Merge this PR and wait for changes to be deployed to Staging.
2. Test the newly created Ingress in Staging by:
    `curl -i -H "host: rosalind-staging.artsy.net" -k https://a2b7b9ff4afbf11ea976f123b14b93be-bc5647bbe8f5b617.elb.us-east-1.amazonaws.com`
3. Switch Staging DNS to Ingress by updating on Cloudflare as follows:
    `rosalind-staging.artsy.net` -> `a2b7b9ff4afbf11ea976f123b14b93be-bc5647bbe8f5b617.elb.us-east-1.amazonaws.com`
3. Merge the `Deploy` PR that will be automatically generated. Wait for changes to be deployed to Production.
4. Test the newly created Ingress in Production by:
    `curl -i -H "host: rosalind.artsy.net" -k https://a0e5e98faaf2311eaa26a0a55b7aece7-04d12ab5797eaa99.elb.us-east-1.amazonaws.com`
5. Switch Production DNS to Ingress by updating on Cloudflare as follows:
    `rosalind.artsy.net` -> `a0e5e98faaf2311eaa26a0a55b7aece7-04d12ab5797eaa99.elb.us-east-1.amazonaws.com`