### PR TITLE
#migration drop ELB service and Nginx sidecar.

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -62,37 +62,6 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
-        - name: rosalind-nginx
-          image: artsy/docker-nginx:1.14.2
-          ports:
-            - name: nginx-http
-              containerPort: 80
-            - name: nginx-https
-              containerPort: 443
-          readinessProbe:
-            tcpSocket:
-              port: nginx-http
-            initialDelaySeconds: 5
-            periodSeconds: 15
-            timeoutSeconds: 10
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/usr/sbin/nginx", "-s", "quit"]
-          env:
-            - name: 'NGINX_DEFAULT_CONF'
-              valueFrom:
-                configMapKeyRef:
-                  name: nginx-config
-                  key: default
-          volumeMounts:
-            - name: nginx-secrets
-              mountPath: /etc/nginx/ssl
-      volumes:
-        - name: nginx-secrets
-          secret:
-            secretName: nginx-secrets
-            defaultMode: 420
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:
@@ -121,38 +90,6 @@ spec:
   minReplicas: 2
   maxReplicas: 6
   targetCPUUtilizationPercentage: 70
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: rosalind
-    component: web
-    layer: application
-  name: rosalind-web
-  namespace: default
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ artsyNetWildcardSSLCert }}
-    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
-spec:
-  ports:
-    - port: 80
-      protocol: TCP
-      name: http
-      targetPort: nginx-http
-    - port: 443
-      protocol: TCP
-      name: https
-      targetPort: nginx-http
-  selector:
-    app: rosalind
-    layer: application
-    component: web
-  sessionAffinity: None
-  type: LoadBalancer
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -62,37 +62,6 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
-        - name: rosalind-nginx
-          image: artsy/docker-nginx:1.14.2
-          ports:
-            - name: nginx-http
-              containerPort: 80
-            - name: nginx-https
-              containerPort: 443
-          readinessProbe:
-            tcpSocket:
-              port: nginx-http
-            initialDelaySeconds: 5
-            periodSeconds: 15
-            timeoutSeconds: 10
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/usr/sbin/nginx", "-s", "quit"]
-          env:
-            - name: 'NGINX_DEFAULT_CONF'
-              valueFrom:
-                configMapKeyRef:
-                  name: nginx-config
-                  key: default
-          volumeMounts:
-            - name: nginx-secrets
-              mountPath: /etc/nginx/ssl
-      volumes:
-        - name: nginx-secrets
-          secret:
-            secretName: nginx-secrets
-            defaultMode: 420
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:
@@ -121,38 +90,6 @@ spec:
   minReplicas: 1
   maxReplicas: 6
   targetCPUUtilizationPercentage: 70
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: rosalind
-    component: web
-    layer: application
-  name: rosalind-web
-  namespace: default
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ artsyNetWildcardSSLCert }}
-    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
-spec:
-  ports:
-    - port: 80
-      protocol: TCP
-      name: http
-      targetPort: nginx-http
-    - port: 443
-      protocol: TCP
-      name: https
-      targetPort: nginx-http
-  selector:
-    app: rosalind
-    layer: application
-    component: web
-  sessionAffinity: None
-  type: LoadBalancer
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler


### PR DESCRIPTION
Follow-up on https://github.com/artsy/rosalind/pull/402.

Migration
---
1. Merge and deploy this PR
2. Delete the "rosalind-web" service

Staging:https://kubernetes-staging.artsy.net/#!/service/default/rosalind-web?namespace=default
Production: https://kubernetes.artsy.net/#!/service/default/rosalind-web?namespace=default
See docs in https://www.notion.so/artsy/Nginx-Ingress-Controllers-4b5d937f0acd480f938c34ef1509d3c4 section Migrating an application from an external LoadBalancer-fronted service to an Ingress-fronted service