### PR TITLE
feat: add Coverband gem for production coverage reporting #FF 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,3 +46,4 @@ group :test do
   gem 'webmock'
 end
 
+gem 'coverband'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,8 @@ GEM
     connection_pool (2.2.2)
     cork (0.3.0)
       colored2 (~> 3.1)
+    coverband (5.0.3)
+      redis
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.5)
@@ -365,6 +367,7 @@ PLATFORMS
 DEPENDENCIES
   capybara
   coffee-rails
+  coverband
   danger
   ddtrace
   decent_exposure

--- a/config/coverband.rb
+++ b/config/coverband.rb
@@ -1,0 +1,15 @@
+Coverband.configure do |config|
+  # supress some commonly un-informative file reports
+  # https://github.com/danmayer/coverband/#ignoring-files
+  config.ignore +=  [
+    'app/mailers/*',
+    'bin/*',
+    'config/application.rb',
+    'config/boot.rb',
+    'config/environments/*',
+    'config/puma.rb',
+    'config/schedule.rb',
+    'config/spring.rb',
+    'lib/tasks/*'
+  ]
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,5 +15,6 @@ Rails.application.routes.draw do
   get 'match/partners'
   get 'match/artists'
 
-  mount Sidekiq::Web => '/sidekiq', :constraints => AdminConstraint.new
+  mount Sidekiq::Web, at: '/sidekiq', constraints: AdminConstraint.new
+  mount Coverband::Reporters::Web.new, at: '/coverage', constraints: AdminConstraint.new
 end


### PR DESCRIPTION
This is a little spike to see about instrumenting production Ruby apps in order to find dead & forgotten code.

I don't expect this app to actually have much of that, but it's a good guinea pig, before deciding whether to try this on larger & older apps.

The coverage and reporting come from the [Coverband](https://github.com/danmayer/coverband/) gem, suggested in [this Slack thread](https://artsy.slack.com/archives/CA8SANW3W/p1597769696461300?thread_ts=1597769645.460800&cid=CA8SANW3W).

![Screen Shot 2020-10-09 at 4 17 09 PM](https://user-images.githubusercontent.com/140521/95627890-fa696180-0a4a-11eb-9896-c4558ce22935.png)
