### PR TITLE
Enable the one shot coverage feature

### DIFF
--- a/config/coverband.rb
+++ b/config/coverband.rb
@@ -12,4 +12,6 @@ Coverband.configure do |config|
     'config/spring.rb',
     'lib/tasks/*'
   ]
+
+  config.use_oneshot_lines_coverage = true
 end


### PR DESCRIPTION
This enables the one-shot code coverage feature available in Ruby >= 2.6. This is a relatively new feature added to Ruby 2.6: https://bugs.ruby-lang.org/issues/15022
> Traditional coverage tells us "how many times each line was executed". However, it is often enough just to know "whether each line was executed at least once, or not". In this case, the counting just bring unneeded overhead.
>
> Oneshot coverage records only the first execution of each line, and returns line numbers of newly executed lines. It contains less information than traditional coverage, but still useful in many use cases. The hook for each line is executed just once, so after it was fired, the program can run with zero-overhead.

The `coverband` gem has added support for this feature https://github.com/danmayer/coverband/pull/264 a while back, so we should be able to take advantage of it.