### PR TITLE
Fix docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN adduser --disabled-password --gecos '' deploy && \
     mkdir /shared/sockets && \
     chown -R deploy:deploy /shared
 
-RUN gem install bundler
+RUN gem install bundler:1.17.2
 
 # Throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1


### PR DESCRIPTION
This updates `Dockerfile` to match the bundler version specified in `Gemfile.lock`. I'm not particularly attached to this version, nor am I sure why it [started failing](https://app.circleci.com/pipelines/github/artsy/rosalind) in the last few weeks.