### PR TITLE
fix(puma): remove obsolete daemonize config

### DIFF
--- a/config/puma.config
+++ b/config/puma.config
@@ -2,7 +2,6 @@
 
 directory "/app"
 environment ENV.fetch("RAILS_ENV") { "development" }
-daemonize false
 pidfile  "/shared/pids/puma.pid"
 state_path "/shared/pids/puma.state"
 threads ENV.fetch("PUMA_THREAD_MIN") { 0 }.to_i, ENV.fetch("PUMA_THREAD_MAX") { 16 }.to_i


### PR DESCRIPTION
Slack thread: https://artsy.slack.com/archives/CA8SANW3W/p1646146564368129

Puma was bumped from v4 to v5 recently, but we didn't account for the removal of the `daemonize` config option (https://github.com/puma/puma/pull/2170)
