### PR TITLE
feat: upgrade datadog tracer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,8 +117,10 @@ GEM
       no_proxy_fix
       octokit (~> 4.7)
       terminal-table (~> 1)
-    ddtrace (0.30.0)
+    ddtrace (0.54.2)
+      debase-ruby_core_source (<= 0.10.14)
       msgpack
+    debase-ruby_core_source (0.10.14)
     decent_exposure (3.0.2)
       activesupport (>= 4.0)
     diff-lcs (1.3)
@@ -176,7 +178,7 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
     minitest (5.15.0)
-    msgpack (1.3.1)
+    msgpack (1.5.1)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)


### PR DESCRIPTION
To support [Datadog Deployment Tracking](https://docs.datadoghq.com/tracing/deployment_tracking/) feature.