### PR TITLE
build: ensure latest GPG public key from Google

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ ENV LANG C.UTF-8
 
 ARG BUNDLE_GITHUB__COM
 
+RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
+
 RUN apt-get update -qq && apt-get install -y \
   dumb-init \
   libpq-dev \


### PR DESCRIPTION
Fixes broken Docker builds in CI

See: https://artsy.slack.com/archives/CP9P4KR35/p1658497818220129