### PR TITLE
feat(filter artworks): update controller to fetch results from Gravity

### DIFF
--- a/app/controllers/filter_controller.rb
+++ b/app/controllers/filter_controller.rb
@@ -1,0 +1,15 @@
+class FilterController < ApplicationController
+  def artworks
+    valid_params = params.permit(
+      FilteredArtworkSearchService::ALLOWED_PARAMS,
+      # HACK: Per the Strong Parameters convention, array-valued params
+      # must be mapped to an empty array, so the allowlist above
+      # isn't quite sufficient. We therefore redundantly add…
+      gene_ids: [],
+      artist_ids: []
+    ).to_h
+
+    response = FilteredArtworkSearchService.call(valid_params)
+    render json: response
+  end
+end

--- a/app/controllers/match_controller.rb
+++ b/app/controllers/match_controller.rb
@@ -5,6 +5,20 @@ class MatchController < ApplicationController
     render json: response
   end
 
+  def filter_artworks
+    valid_params = params.permit(
+      FilteredArtworkSearchService::ALLOWED_PARAMS,
+      # HACK: Per the Strong Parameters convention, array-valued params
+      # must be mapped to an empty array, so the allowlist above
+      # isn't quite sufficient. We therefore redundantly add…
+      gene_ids: [],
+      artist_ids: []
+    ).to_h
+
+    response = FilteredArtworkSearchService.call(valid_params)
+    render json: response
+  end
+
   def genes
     term = params.require(:term)
     genes = Gene.match term: term, size: 5

--- a/app/services/filtered_artwork_search_service.rb
+++ b/app/services/filtered_artwork_search_service.rb
@@ -1,9 +1,27 @@
 module FilteredArtworkSearchService
   class ServiceError < StandardError; end
 
+  ALLOWED_PARAMS = %i[
+    acquireable
+    artist_ids
+    attribution_class
+    fair_id
+    for_sale
+    gene_ids
+    keyword
+    offerable
+    partner_id
+    price_range
+    sort
+    tag_id
+  ].freeze
+
   class << self
     def call(params = {})
+      validate_parameters!(params)
+
       response = Typhoeus.get(api_url, params: params, params_encoding: :rack, headers: headers, accept_encoding: 'gzip')
+
       if response.success?
         JSON.parse(response.body)
       else
@@ -27,6 +45,12 @@ module FilteredArtworkSearchService
         # TODO: replace with user access token, to support fetching unpublished works
         'X-XAPP-TOKEN' => Rails.application.config_for(:gravity)['xapp_token']
       }
+    end
+
+    def validate_parameters!(params)
+      actual_params = params.symbolize_keys.keys
+      unrecognized_params = actual_params - ALLOWED_PARAMS
+      raise ServiceError, "Unrecognized parameters: #{unrecognized_params.inspect}" if unrecognized_params.any?
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
 
   # searches and autocompletes
   post 'match/artworks'
-  get 'match/filter_artworks'
+  get 'filter/artworks'
   get 'match/genes'
   get 'match/tags'
   get 'match/fairs'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
 
   # searches and autocompletes
   post 'match/artworks'
+  get 'match/filter_artworks'
   get 'match/genes'
   get 'match/tags'
   get 'match/fairs'

--- a/spec/controllers/filter_controller_spec.rb
+++ b/spec/controllers/filter_controller_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe FilterController, type: :controller do
+  context 'with a logged in admin' do
+    include_context 'logged in admin'
+
+    describe '#artworks' do
+      let(:params) do
+        { for_sale: true, attribution_class: 'unique', gene_ids: ['sculpture'] }
+      end
+
+      let(:artwork_hit) { read_sample_artwork_fixture }
+
+      let(:response) do
+        { hits: [artwork_hit], aggregations: [] }
+      end
+
+      let!(:gravity_request) do
+        stub_filter_artworks_request(200, params, response.to_json)
+      end
+
+      it 'issues the correct gravity query' do
+        get :artworks, params: params
+        expect(gravity_request).to have_been_made
+      end
+    end
+  end
+end

--- a/spec/controllers/match_controller_spec.rb
+++ b/spec/controllers/match_controller_spec.rb
@@ -15,6 +15,27 @@ RSpec.describe MatchController, type: :controller do
       end
     end
 
+    describe '#filter_artworks' do
+      let(:params) do
+        { for_sale: true, attribution_class: 'unique', gene_ids: ['sculpture'] }
+      end
+
+      let(:artwork_hit) { read_sample_artwork_fixture }
+
+      let(:response) do
+        { hits: [artwork_hit], aggregations: [] }
+      end
+
+      let!(:gravity_request) do
+        stub_filter_artworks_request(200, params, response.to_json)
+      end
+
+      it 'issues the correct gravity query' do
+        get :filter_artworks, params: params
+        expect(gravity_request).to have_been_made
+      end
+    end
+
     describe '#genes' do
       let(:gene) { Fabricate(:kinetic_gene, name: 'Photojournalism') }
       let!(:gravity_request) { Kinetic::Stub::Gravity::GravityModel.match([gene]) }

--- a/spec/controllers/match_controller_spec.rb
+++ b/spec/controllers/match_controller_spec.rb
@@ -15,27 +15,6 @@ RSpec.describe MatchController, type: :controller do
       end
     end
 
-    describe '#filter_artworks' do
-      let(:params) do
-        { for_sale: true, attribution_class: 'unique', gene_ids: ['sculpture'] }
-      end
-
-      let(:artwork_hit) { read_sample_artwork_fixture }
-
-      let(:response) do
-        { hits: [artwork_hit], aggregations: [] }
-      end
-
-      let!(:gravity_request) do
-        stub_filter_artworks_request(200, params, response.to_json)
-      end
-
-      it 'issues the correct gravity query' do
-        get :filter_artworks, params: params
-        expect(gravity_request).to have_been_made
-      end
-    end
-
     describe '#genes' do
       let(:gene) { Fabricate(:kinetic_gene, name: 'Photojournalism') }
       let!(:gravity_request) { Kinetic::Stub::Gravity::GravityModel.match([gene]) }

--- a/spec/services/filtered_artwork_search_service_spec.rb
+++ b/spec/services/filtered_artwork_search_service_spec.rb
@@ -41,6 +41,14 @@ RSpec.describe FilteredArtworkSearchService, type: :model do
       expect(response['hits'][0]).to eq artwork_hit
     end
 
+    context 'with unrecognized parameters' do
+      it 'raises an error' do
+        expect do
+          FilteredArtworkSearchService.call({ lol: 'jkjk' })
+        end.to raise_error FilteredArtworkSearchService::ServiceError, /Unrecognized parameters/
+      end
+    end
+
     context 'on failure' do
       let(:params) do
         { sort: 'lolol' }
@@ -62,7 +70,7 @@ RSpec.describe FilteredArtworkSearchService, type: :model do
         stub_filter_artworks_request(400, params, response.to_json)
         expect do
           FilteredArtworkSearchService.call(params)
-        end.to raise_error FilteredArtworkSearchService::ServiceError
+        end.to raise_error FilteredArtworkSearchService::ServiceError, /Invalid parameters/
       end
     end
   end

--- a/spec/services/filtered_artwork_search_service_spec.rb
+++ b/spec/services/filtered_artwork_search_service_spec.rb
@@ -3,11 +3,6 @@ require './app/services/filtered_artwork_search_service'
 
 RSpec.describe FilteredArtworkSearchService, type: :model do
   describe '.call' do
-    def stub_filter_artworks_request(status, params, body)
-      endpoint = "#{Rails.application.config_for(:gravity)['api_root']}/filter/artworks"
-      WebMock.stub_request(:get, endpoint).with(query: params).to_return(status: status, body: body, headers: {})
-    end
-
     let(:params) do
       # kitchen-sink query that should match kiki-smith-the-falls-i
       {
@@ -32,9 +27,7 @@ RSpec.describe FilteredArtworkSearchService, type: :model do
       { hits: [artwork_hit], aggregations: [] }
     end
 
-    let(:artwork_hit) do
-      JSON.parse(File.read('./spec/fixtures/kiki-smith-the-falls-i.json'))
-    end
+    let(:artwork_hit) { read_sample_artwork_fixture }
 
     it 'issues the correct gravity request' do
       request = stub_filter_artworks_request(200, params, response.to_json)

--- a/spec/support/gravity.rb
+++ b/spec/support/gravity.rb
@@ -1,0 +1,8 @@
+def stub_filter_artworks_request(status, params, body)
+  endpoint = "#{Rails.application.config_for(:gravity)['api_root']}/filter/artworks"
+  WebMock.stub_request(:get, endpoint).with(query: params).to_return(status: status, body: body, headers: {})
+end
+
+def read_sample_artwork_fixture
+  JSON.parse(File.read('./spec/fixtures/kiki-smith-the-falls-i.json'))
+end


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-4109

This continues laying the server-side foundation for Rosalind talking to Gravity's `filter/artworks` endpoint by

- enumerating the query params that can be accepted and forward on to Gravity (necessitated by Rails's strong parameters convention — though I wonder about that, see below)
- calling the new `FilteredArtworkSearchService`, to do the forwarding

This means we can hit Gravity's filter/artworks via Rosalind's API now, so that we can start using this in the frontend.

Examples:

- localhost: http://localhost:5000/filter/artworks?keyword=soup&attribution_class=unique&artist_ids[]=andy-warhol&artist_ids[]=banksy

- staging [after this is merged]: https://rosalind-staging.artsy.net/filter/artworks?keyword=soup&attribution_class=unique&artist_ids[]=andy-warhol&artist_ids[]=banksy

