### PR TITLE
chore: remove unneeded ES basic auth

### DIFF
--- a/app/services/artwork_search_service.rb
+++ b/app/services/artwork_search_service.rb
@@ -3,7 +3,7 @@ module ArtworkSearchService
 
   class << self
     def call(query:)
-      response = Typhoeus.post(api_url, body: query, userpwd: basic_auth_credentials,
+      response = Typhoeus.post(api_url, body: query,
                                         headers: headers, accept_encoding: 'gzip')
       if response.success?
         response.body
@@ -19,10 +19,6 @@ module ArtworkSearchService
     def api_url
       "#{Rails.application.config_for(:elasticsearch)['url']}/#{Rails.application.config_for(:elasticsearch)['index']}" \
         '/_search'
-    end
-
-    def basic_auth_credentials
-      "#{Rails.application.config_for(:elasticsearch)['username']}:#{Rails.application.config_for(:elasticsearch)['password']}"
     end
 
     def headers

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -1,8 +1,6 @@
 development: &default
   url: <%= ENV['ELASTICSEARCH_URL'] || 'http://localhost:9200' %>
   index: <%= ENV['ELASTICSEARCH_INDEX'] || 'gravity' %>
-  username: <%= ENV['ELASTICSEARCH_USERNAME'] || 'replace' %>
-  password: <%= ENV['ELASTICSEARCH_PASSWORD'] || 'replace' %>
 test:
   <<: *default
 production:

--- a/spec/support/elasticsearch.rb
+++ b/spec/support/elasticsearch.rb
@@ -1,8 +1,8 @@
 def stub_elasticsearch_request(path:, query:, response_hits:)
-  root_url, index_name, user, pass = Rails.application.config_for(:elasticsearch)
-                                          .values_at 'url', 'index', 'username', 'password'
+  root_url, index_name = Rails.application.config_for(:elasticsearch)
+                              .values_at 'url', 'index'
   WebMock.stub_request(:post, "#{root_url}/#{index_name}/#{path}")
-         .with(body: query, basic_auth: [user, pass])
+         .with(body: query)
          .to_return(body: { hits: { hits: response_hits } }.to_json)
 end
 


### PR DESCRIPTION
Basic auth isn't used in the new cluster as it's in the VPC (like the old cluster) which now loudly complains (vs. the old one which silently accepted any credentials!).

Didn't catch this b/c when running Rosalind locally a couple of weeks ago I was pointing to a test v6 cluster I had setup w/ basic auth.