### PR TITLE
chore: use circleci bundle-github context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,45 +2,57 @@ version: 2.1
 orbs:
   hokusai: artsy/hokusai@volatile
   horizon: artsy/release@volatile
+
 not_staging_or_release: &not_staging_or_release
   filters:
     branches:
       ignore:
         - staging
         - release
+
 only_main: &only_main
-  context: hokusai
   filters:
     branches:
       only: main
+
 only_release: &only_release
-  context: hokusai
   filters:
     branches:
       only: release
+
 workflows:
   build-deploy:
     jobs:
       # pre-staging
       - hokusai/test:
-          name: test
           <<: *not_staging_or_release
+          context: bundle-github
+          name: test
+
       # staging
       - hokusai/push:
-          name: push-staging-image
           <<: *only_main
+          context:
+            - hokusai
+            - bundle-github
+          name: push-staging-image
           requires:
             - test
+
       - hokusai/deploy-staging:
           <<: *only_main
+          context: hokusai
           project-name: rosalind
           requires:
             - push-staging-image
+
       # release
       - hokusai/deploy-production:
           <<: *only_release
+          context: hokusai
           requires:
             - horizon/block
+
       - horizon/block:
           <<: *only_release
           context: horizon

--- a/spec/system/user_searches_artworks_spec.rb
+++ b/spec/system/user_searches_artworks_spec.rb
@@ -69,7 +69,7 @@ describe 'User searches artworks', js: true do
 
     find('.remove').click
 
-    expect(page).to_not have_selected_tag('Kawaii')
+    expect(page).to_not have_selected_tag('Monster')
     expect(page).to have_no_results
   end
 


### PR DESCRIPTION
Solves https://artsyproduct.atlassian.net/browse/PHIRE-80

Read `BUNDLE_GITHUB__COM` from CircleCI _context_ when building an image in CI.

_rosalind_ project CI pipleine uses [hokusai orb jobs](https://github.com/artsy/orbs/blob/7c26a69a6b560d6acb4b31fb267244d89ea42d6a/src/hokusai/hokusai.yml#L113-L150) for [executing _tests_ and _pushing_](https://github.com/artsy/rosalind/blob/a2c08e2bd51a978abb2c14b03ee8f1571370261b/.circleci/config.yml#L25-L33) to the image repository. Both jobs perform a docker build and thus depend on that variable as declared in the [Dockerfile](https://github.com/artsy/rosalind/blob/main/Dockerfile). `bundle-github` context is therefore added in two places: _test_ and _push_ jobs.

Also, move contexts' into jobs.

## Migration

1. unset `BUNDLE_GITHUB__COM` in [rosalind CircleCI Project Environment Variables](https://app.circleci.com/settings/project/github/artsy/rosalind/environment-variables?return-to=https%3A%2F%2Fapp.circleci.com%2Fpipelines%2Fgithub%2Fartsy%2Frosalind)
2. merge PR
