### PR TITLE
fix: exec probes without timeout setting

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -181,6 +181,7 @@ spec:
             - sidekiq
           initialDelaySeconds: 30
           periodSeconds: 30
+          timeoutSeconds: 3
         resources:
           requests:
             cpu: 200m

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -181,6 +181,7 @@ spec:
             - sidekiq
           initialDelaySeconds: 30
           periodSeconds: 30
+          timeoutSeconds: 3
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
fix: exec probes without timeout setting