### PR TITLE
chore: prepare for elasticsearch v7 (ONYX-845)

### DIFF
--- a/spec/support/elasticsearch.rb
+++ b/spec/support/elasticsearch.rb
@@ -11,7 +11,6 @@ def elasticsearch_sample_artwork_hits
   [
     {
       '_index' => 'gravity',
-      '_type' => 'artwork',
       '_id' => '1234',
       '_source' => {
         'id' => '1234',
@@ -23,7 +22,6 @@ def elasticsearch_sample_artwork_hits
     },
     {
       '_index' => 'gravity',
-      '_type' => 'artwork',
       '_id' => '5678',
       '_source' => {
         'id' => '5678',


### PR DESCRIPTION
This is just a small change for consistency, and can merge _ahead_ of the upcoming Elasticsearch upgrade. Going forward, `_type` is always `"_doc"`. The tests don't rely on that field anyway, so just cleaning up the potentially confusing data.