### PR TITLE
fix: update parsing of ES hits' total count

### DIFF
--- a/app/javascript/components/batch_update/components/SearchResults.js
+++ b/app/javascript/components/batch_update/components/SearchResults.js
@@ -119,7 +119,7 @@ const Controls = ({
 }) => (
   <div>
     <div className="counts">
-      Displaying {displayed.toLocaleString()} of {total.toLocaleString()}{' '}
+      Displaying {displayed.toLocaleString()} of {total.value.toLocaleString()}{' '}
       matching artworks
     </div>
     <div className="select">

--- a/spec/system/user_searches_artworks_spec.rb
+++ b/spec/system/user_searches_artworks_spec.rb
@@ -33,7 +33,7 @@ describe 'User searches artworks', js: true do
     ]
   end
 
-  let(:search_response) { { hits: { total: hits.count, hits: hits } }.to_json }
+  let(:search_response) { { hits: { total: { value: hits.count }, hits: hits } }.to_json }
 
   scenario 'by gene' do
     gene = { 'id' => 'kawaii', 'name' => 'Kawaii' }

--- a/spec/system/user_updates_artworks_spec.rb
+++ b/spec/system/user_updates_artworks_spec.rb
@@ -34,7 +34,7 @@ describe 'User updates artworks', js: true do
     ]
   end
 
-  let(:search_response) { { hits: { total: hits.count, hits: hits } }.to_json }
+  let(:search_response) { { hits: { total: { value: hits.count }, hits: hits } }.to_json }
 
   before do
     ActionController::Base.allow_forgery_protection = true


### PR DESCRIPTION
As [noted](https://artsy.slack.com/archives/C05EQL4R5N0/p1707432496566099?thread_ts=1707404055.385329&cid=C05EQL4R5N0) when planning out the ES 7 upgrade: [`hits.total` is now an object in the search response](https://artsy.slack.com/archives/C05EQL4R5N0/p1707432496566099?thread_ts=1707404055.385329&cid=C05EQL4R5N0)

This accounts for that, and fixes this glitch:

## Before

![Screenshot 2024-03-13 at 5 31 59 PM](https://github.com/artsy/rosalind/assets/140521/1bb7bf25-2487-413d-afe9-51f804d849b4)

## After

![Screenshot 2024-03-13 at 5 32 29 PM](https://github.com/artsy/rosalind/assets/140521/af7961ba-bbf9-4157-a92e-c8b83464380e)


