### PR TITLE
fix: Load More pagination based on ES7 hit counts

### DIFF
--- a/app/javascript/components/batch_update/components/App.tsx
+++ b/app/javascript/components/batch_update/components/App.tsx
@@ -73,7 +73,7 @@ class App extends React.Component<Props, State> {
     size: 100,
     sort: 'RECENTLY_PUBLISHED',
     tags: [],
-    totalHits: null,
+    totalHits: { value: 0, relation: 'eq' },
   }
 
   constructor(props: never) {
@@ -196,7 +196,7 @@ class App extends React.Component<Props, State> {
       this.setState({
         artworks: [],
         selectedArtworkIds: [],
-        totalHits: 0,
+        totalHits: { value: 0, relation: 'eq' },
       })
     } else {
       const query = buildElasticsearchQuery({

--- a/app/javascript/components/batch_update/components/App.tsx
+++ b/app/javascript/components/batch_update/components/App.tsx
@@ -42,7 +42,10 @@ type State = {
   size: number
   sort: string /* enum */
   tags: Tag[]
-  totalHits: number
+  totalHits: {
+    value: number
+    relation: string
+  }
 }
 
 class App extends React.Component<Props, State> {

--- a/app/javascript/components/batch_update/components/SearchResults.js
+++ b/app/javascript/components/batch_update/components/SearchResults.js
@@ -47,7 +47,7 @@ class SearchResults extends React.Component {
       onSelectAllArtworks,
       onDeselectAllArtworks,
     } = this.props
-    if (totalHits && artworks && artworks.length > 0) {
+    if (totalHits.value && artworks && artworks.length > 0) {
       return (
         <Controls
           displayed={artworks.length}
@@ -63,7 +63,7 @@ class SearchResults extends React.Component {
 
   maybeRenderMoreButton() {
     const { artworks, totalHits, onLoadMore } = this.props
-    if (totalHits > artworks.length) {
+    if (totalHits.value > artworks.length) {
       return <LoadMore onLoadMore={onLoadMore} />
     } else {
       return null
@@ -108,7 +108,10 @@ SearchResults.propTypes = {
   onToggleArtwork: PropTypes.func,
   previewedArtwork: PropTypes.object,
   selectedArtworkIds: PropTypes.arrayOf(PropTypes.string),
-  totalHits: PropTypes.number,
+  totalHits: PropTypes.shape({
+    value: PropTypes.string,
+    relation: PropTypes.string,
+  }),
 }
 
 const Controls = ({

--- a/app/javascript/components/batch_update/components/SearchResults.js
+++ b/app/javascript/components/batch_update/components/SearchResults.js
@@ -118,10 +118,7 @@ const Controls = ({
   onDeselectAllArtworks,
 }) => (
   <div>
-    <div className="counts">
-      Displaying {displayed.toLocaleString()} of {total.value.toLocaleString()}{' '}
-      matching artworks
-    </div>
+    <Counts displayed={displayed} total={total} />
     <div className="select">
       Select:
       <Link
@@ -146,6 +143,18 @@ const Controls = ({
     </div>
   </div>
 )
+
+const Counts = ({ displayed, total }) => {
+  const totalCount = total.value.toLocaleString()
+  const hasMore = total.relation === 'gte'
+
+  return (
+    <div className="counts">
+      Displaying {displayed.toLocaleString()} of {totalCount.toLocaleString()}
+      {hasMore ? '+' : ''} matching artworks
+    </div>
+  )
+}
 
 const ArtworkResultList = ({
   artworks,

--- a/app/javascript/components/batch_update/components/SearchResults.spec.js
+++ b/app/javascript/components/batch_update/components/SearchResults.spec.js
@@ -28,6 +28,7 @@ it('renders a collection of artworks', () => {
   const rendered = renderer.create(
     <SearchResults
       artworks={artworks}
+      totalHits={{}}
       selectedArtworkIds={selectedArtworkIds}
     />
   )
@@ -40,6 +41,7 @@ it('renders a modal when previewing', () => {
     <SearchResults
       previewedArtwork={soup}
       artworks={artworks}
+      totalHits={{}}
       selectedArtworkIds={selectedArtworkIds}
     />
   )
@@ -52,6 +54,7 @@ it('does not render a modal when not previewing', () => {
     <SearchResults
       previewedArtwork={null}
       artworks={artworks}
+      totalHits={{}}
       selectedArtworkIds={selectedArtworkIds}
     />
   )
@@ -65,6 +68,7 @@ it('renders a spinner while fetching artworks', () => {
       isLoading
       previewedArtwork={null}
       artworks={artworks}
+      totalHits={{}}
       selectedArtworkIds={selectedArtworkIds}
     />
   )


### PR DESCRIPTION
#775 fixed a display issue that resulted from the change in `hits.total`'s shape starting with ES7

Turns out there was a more substantive issue too — **Load More** pagination was broken, and needed to be taught about the new shape.

I also made the UI handle the case where have more than 10K results (indicated in the response by `{ hits: { total: { value: 10000, relation: "gte" } } }` 

&nbsp;
<img src="https://github.com/artsy/rosalind/assets/140521/44877cef-1bf6-4f38-91aa-1bd698660307" width=500 />

