### PR TITLE
chore(AMBER-541): Display the visibility level on search results

### DIFF
--- a/app/javascript/components/batch_update/components/ArtworkSearchResult.js
+++ b/app/javascript/components/batch_update/components/ArtworkSearchResult.js
@@ -26,7 +26,11 @@ class ArtworkSearchResult extends React.Component {
     return (
       <div className={className} onClick={this.handleClick}>
         <img src={imageUrl || missingImage} alt={name} />
-        <figcaption>{name}</figcaption>
+        <figcaption>
+          {name}
+          <br />
+          {`Visibility level: ${artwork.visibility_level}`}
+        </figcaption>
       </div>
     )
   }

--- a/app/javascript/components/batch_update/components/ArtworkSearchResult.spec.js
+++ b/app/javascript/components/batch_update/components/ArtworkSearchResult.spec.js
@@ -13,6 +13,7 @@ beforeEach(() => {
       name: 'Soup Can',
       image_url: 'can.jpg',
       deleted: false,
+      visibility_level: 'listed',
       published: true,
     },
     onPreviewArtwork: jest.fn(),

--- a/app/javascript/components/batch_update/components/SearchResults.spec.js
+++ b/app/javascript/components/batch_update/components/SearchResults.spec.js
@@ -12,6 +12,7 @@ beforeEach(() => {
     image_url: 'can.jpg',
     deleted: false,
     published: true,
+    visibility_level: 'listed',
   }
   shark = {
     id: 'shark',
@@ -19,6 +20,7 @@ beforeEach(() => {
     image_url: 'shark.jpg',
     deleted: false,
     published: true,
+    visibility_level: 'unlisted',
   }
   artworks = [soup, shark]
   selectedArtworkIds = []

--- a/app/javascript/components/batch_update/components/__snapshots__/ArtworkSearchResult.spec.js.snap
+++ b/app/javascript/components/batch_update/components/__snapshots__/ArtworkSearchResult.spec.js.snap
@@ -32,6 +32,8 @@ exports[`renders correctly 1`] = `
   />
   <figcaption>
     Soup Can
+    <br />
+    Visibility level: listed
   </figcaption>
 </div>
 `;
@@ -71,6 +73,8 @@ exports[`renders in the selected state 1`] = `
   />
   <figcaption>
     Soup Can
+    <br />
+    Visibility level: listed
   </figcaption>
 </div>
 `;

--- a/app/javascript/components/batch_update/components/__snapshots__/SearchResults.spec.js.snap
+++ b/app/javascript/components/batch_update/components/__snapshots__/SearchResults.spec.js.snap
@@ -75,6 +75,8 @@ exports[`does not render a modal when not previewing 1`] = `
       />
       <figcaption>
         Soup Can
+        <br />
+        Visibility level: listed
       </figcaption>
     </div>
     <div
@@ -87,6 +89,8 @@ exports[`does not render a modal when not previewing 1`] = `
       />
       <figcaption>
         Shark
+        <br />
+        Visibility level: unlisted
       </figcaption>
     </div>
   </div>
@@ -168,6 +172,8 @@ exports[`renders a collection of artworks 1`] = `
       />
       <figcaption>
         Soup Can
+        <br />
+        Visibility level: listed
       </figcaption>
     </div>
     <div
@@ -180,6 +186,8 @@ exports[`renders a collection of artworks 1`] = `
       />
       <figcaption>
         Shark
+        <br />
+        Visibility level: unlisted
       </figcaption>
     </div>
   </div>
@@ -417,6 +425,8 @@ exports[`renders a modal when previewing 1`] = `
       />
       <figcaption>
         Soup Can
+        <br />
+        Visibility level: listed
       </figcaption>
     </div>
     <div
@@ -429,6 +439,8 @@ exports[`renders a modal when previewing 1`] = `
       />
       <figcaption>
         Shark
+        <br />
+        Visibility level: unlisted
       </figcaption>
     </div>
   </div>
@@ -551,6 +563,8 @@ exports[`renders a spinner while fetching artworks 1`] = `
       />
       <figcaption>
         Soup Can
+        <br />
+        Visibility level: listed
       </figcaption>
     </div>
     <div
@@ -563,6 +577,8 @@ exports[`renders a spinner while fetching artworks 1`] = `
       />
       <figcaption>
         Shark
+        <br />
+        Visibility level: unlisted
       </figcaption>
     </div>
   </div>

--- a/spec/support/search_matchers.rb
+++ b/spec/support/search_matchers.rb
@@ -46,7 +46,10 @@ RSpec::Matchers.define :have_results do |hits|
     actual_srcs = page.all(".results img").map { |node| node["src"] }
     expect(actual_srcs).to eq expected_srcs
 
-    expected_captions = hits.map { |hit| hit["_source"]["name"] }
+    expected_captions = hits.map do |hit|
+      "#{hit["_source"]["name"]}\nVisibility level: #{hit["_source"]["visibility_level"]}"
+    end
+
     actual_captions = page.all(".results figcaption").map(&:text)
     expect(actual_captions).to eq expected_captions
   end

--- a/spec/system/user_searches_artworks_spec.rb
+++ b/spec/system/user_searches_artworks_spec.rb
@@ -20,14 +20,16 @@ describe "User searches artworks", js: true do
         "_source" => {
           "id" => "1234",
           "name" => "Pikachu",
-          "image_url" => "https://d32dm0rphc51dk.cloudfront.net/Zm4R54uWxcufME7KJBRxdw/square.jpg"
+          "image_url" => "https://d32dm0rphc51dk.cloudfront.net/Zm4R54uWxcufME7KJBRxdw/square.jpg",
+          "visibility_level" => "listed"
         }
       },
       {
         "_source" => {
           "id" => "5678",
           "name" => "Jigglypuff",
-          "image_url" => "https://d32dm0rphc51dk.cloudfront.net/s8oMXsCa4LFVnsBc7sQluA/square.jpg"
+          "image_url" => "https://d32dm0rphc51dk.cloudfront.net/s8oMXsCa4LFVnsBc7sQluA/square.jpg",
+          "visibility_level" => "unlisted"
         }
       }
     ]


### PR DESCRIPTION
[AMBER-541]

Enable users to distinguish between public and private artworks among the search results.

We do not need filtering capabilities here for now. Enabling users to tell whether the artwork is private is enough.

**Before**
![Screenshot 2024-04-16 at 14 20 33](https://github.com/artsy/rosalind/assets/8002618/e02ac45d-8694-42ad-a5a0-dd4a83a605c1)

**After**
![Screenshot 2024-04-16 at 14 20 27](https://github.com/artsy/rosalind/assets/8002618/191fa025-5ac6-4661-b799-f00c34405196)

@artsy/amber-devs 


[AMBER-541]: https://artsyproduct.atlassian.net/browse/AMBER-541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ