### PR TITLE
chore: fix chrome 114 install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,20 +20,20 @@ RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
 # Temporary install older chrome version
 # Can be reverted back to stable once this project is under Ruby 3
 # and Selenium is updated
+# We need to host our own tar of 114 because chrome has stopped hosting it
+# This is even more reason to get to ruby 3.0 and later selenium and chrome
 
-ENV CHROME_VERSION 114.0.5735.90-1
-RUN curl -o /tmp/chrome-114.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb
-RUN apt-get update -qq && apt-get install -y nodejs libnss3 libgconf-2-4 && apt-get install -y /tmp/chrome-114.deb && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-# RUN echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
-
-# RUN apt-get update -qq
-# RUN apt-get install -y nodejs libnss3 libgconf-2-4 google-chrome-stable
-# RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+ENV CHROME_VERSION 114.0.5735.90
+RUN curl -L -o /tmp/google-chrome.tar.gz https://artsy-public.s3.amazonaws.com/google-chrome/chrome_${CHROME_VERSION}_linux.tar.gz
+RUN tar -xzf /tmp/google-chrome.tar.gz -C /tmp/
+RUN apt -y install /tmp/${CHROME_VERSION}/install-dependencies.deb
+RUN mkdir -p /opt/google/chrome
+RUN cp -R /tmp/${CHROME_VERSION}/* /opt/google/chrome/
 
 # Disable Chrome sandbox
 RUN sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' "/opt/google/chrome/google-chrome"
+
+RUN apt-get update -qq && apt-get install -y nodejs libnss3 libgconf-2-4 && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN gem install bundler -v 2.4.22
 
@@ -41,13 +41,13 @@ RUN npm install -g yarn
 
 # Set up deploy user, working directory and shared folders for Puma / Nginx
 RUN adduser --disabled-password --gecos '' deploy && \
-    mkdir -p /app && \
-    chown deploy:deploy /app && \
-    mkdir /shared && \
-    mkdir /shared/config && \
-    mkdir /shared/pids && \
-    mkdir /shared/sockets && \
-    chown -R deploy:deploy /shared
+  mkdir -p /app && \
+  chown deploy:deploy /app && \
+  mkdir /shared && \
+  mkdir /shared/config && \
+  mkdir /shared/pids && \
+  mkdir /shared/sockets && \
+  chown -R deploy:deploy /shared
 
 RUN gem install bundler:2.1.4
 
@@ -59,7 +59,7 @@ WORKDIR /tmp
 ADD Gemfile Gemfile
 ADD Gemfile.lock Gemfile.lock
 RUN bundle install -j4 && \
-    rm -rf /usr/local/bundle/cache
+  rm -rf /usr/local/bundle/cache
 
 # Switch to deploy user
 USER deploy

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN tar -xzf /tmp/google-chrome.tar.gz -C /tmp/
 RUN apt -y install /tmp/${CHROME_VERSION}/install-dependencies.deb
 RUN mkdir -p /opt/google/chrome
 RUN cp -R /tmp/${CHROME_VERSION}/* /opt/google/chrome/
+# Ensure Chrome is in the PATH
+RUN ln -s /opt/google/chrome/google-chrome /usr/bin/google-chrome
 
 # Disable Chrome sandbox
 RUN sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' "/opt/google/chrome/google-chrome"


### PR DESCRIPTION
Similarly as https://github.com/artsy/ohm/pull/951/files, chrome 114, which is required by pinned selenium-webdriver version, is no longer hosted and so this switched to self hosted version until codebase is on ruby >=3.

