### PR TITLE
chore: Set exact Rails version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby "3.0.7"
 
 gem "pg"
 gem "puma"
-gem "rails", "~> 6.1.7.8"
+gem "rails", "6.1.7.8"
 
 kinetic_gem_spec = {git: "https://github.com/artsy/kinetic.git", branch: "main"}
 # kinetic_gem_spec = { path: '../kinetic' }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -421,7 +421,7 @@ DEPENDENCIES
   pg
   pry-rails
   puma
-  rails (~> 6.1.7.8)
+  rails (= 6.1.7.8)
   rspec-rails
   sassc-rails
   selenium-webdriver


### PR DESCRIPTION
This PR does a very nit-picky thing and sets the exact Rails version in the Gemfile. Mostly this is to keep things more consistent in our Rails apps but it also makes the `artsy_ruby_doctor` project work correctly.

/cc @artsy/amber-devs