### PR TITLE
fix: use bash for secrets script

### DIFF
--- a/scripts/load_secrets_and_run.sh
+++ b/scripts/load_secrets_and_run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 CMD="$@"
 


### PR DESCRIPTION
Patches #808 to use `bash` for the load secrets script