### PR TITLE
Migrate from asdf to mise

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -10,11 +10,11 @@ set -e
 echo "Installing dependencies..."
 brew bundle
 
-if command -v asdf >/dev/null; then
-  echo "Installing language dependencies with asdf"
-  asdf install
+if command -v mise >/dev/null; then
+  echo "Installing language dependencies with mise"
+  mise install
 else
-  echo "Skipping language dependencies installation (asdf not found)"
+  echo "Skipping language dependencies installation (mise not found)"
 fi
 
 echo "Installing dependencies..."


### PR DESCRIPTION
## Summary

Migrates the setup script from asdf to mise for language dependency management.

- Replace `command -v asdf` check with `command -v mise`
- Replace `asdf install` with `mise install`
- Update setup messages to reference mise instead of asdf
- Keep .tool-versions file unchanged (compatible with mise)

## Context

Part of Artsy's migration from asdf to mise for better performance and developer experience. See RFC: https://github.com/artsy/README/issues/550

## Testing

- [ ] Verify setup script works with mise installed
- [ ] Confirm .tool-versions file is still used correctly
- [ ] Test that existing asdf users can still run setup (graceful fallback)