### PR TITLE
feat: staging to use HPAv2

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -117,7 +117,7 @@ spec:
       - name: secrets
         emptyDir: {}
 ---
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: rosalind-web
@@ -129,9 +129,15 @@ spec:
     name: rosalind-web
   minReplicas: 1
   maxReplicas: 6
-  targetCPUUtilizationPercentage: 70
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
 ---
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: rosalind-sidekiq
@@ -143,7 +149,13 @@ spec:
     name: rosalind-sidekiq
   minReplicas: 1
   maxReplicas: 2
-  targetCPUUtilizationPercentage: 80
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
[HPAv2](https://kubernetes.io/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/) is at GA status as of Kubernetes v1.23 which is our current version. v2 adds the ability to scale by memory, by custom metrics, and by combination of metrics. Let's switch to v2.

Jira: [PHIRE-3105](https://artsy.atlassian.net/browse/PHIRE-3105)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PHIRE-3105]: https://artsyproduct.atlassian.net/browse/PHIRE-3105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ