### PR TITLE
feat: production to use HPAv2

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -117,7 +117,7 @@ spec:
       - name: secrets
         emptyDir: {}
 ---
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: rosalind-web
@@ -129,9 +129,15 @@ spec:
     name: rosalind-web
   minReplicas: 2
   maxReplicas: 6
-  targetCPUUtilizationPercentage: 70
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
 ---
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: rosalind-sidekiq
@@ -143,7 +149,13 @@ spec:
     name: rosalind-sidekiq
   minReplicas: 1
   maxReplicas: 2
-  targetCPUUtilizationPercentage: 80
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
HPAv2 is at GA status as of Kubernetes v1.23 which is our current version. v2 adds the ability to scale by memory, by custom metrics, and by combination of metrics. Let us switch to v2.

Jira: PHIRE-3107