### PR TITLE
chore: impose 10d cooldown period before dependency updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source "https://rubygems.org", cooldown: 10
 
 ruby "3.3.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -445,7 +445,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 3.3.0p0
+  ruby 3.3.0p0
 
 BUNDLED WITH
-   2.5.14
+  4.0.17


### PR DESCRIPTION
Mirrors [artsy/gravity#20262](https://github.com/artsy/gravity/pull/20262) — upgrades `bundler` for the ability to specify a `cooldown` argument, delaying dependency updates until they've had 10 days to be vetted elsewhere. This mitigates supply-chain risk from a compromised gem release being auto-picked-up before the community notices.

Requires Bundler >= 4.0.13 for the `cooldown` source option; this repo was still on the 2.x line, so this bumps bundler across a major version (2.5.14 → 4.0.17).


Assisted by Claude Code Sonnet 5